### PR TITLE
Fixed GameInstallationFinder for Below Zero (Steam)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,11 @@
     <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Nitrox.Test'">
         <TestLibrary>true</TestLibrary>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'BelowZero' ">
+        <DefineConstants>DEBUG;BELOWZERO</DefineConstants>
+        <OutputPath>bin\BelowZero\</OutputPath>
+    </PropertyGroup>
+
 
     <!-- Shared dependencies for all Nitrox.* projects -->
     <Choose>

--- a/Nitrox.Analyzers/Nitrox.Analyzers.csproj
+++ b/Nitrox.Analyzers/Nitrox.Analyzers.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Analyzers MUST target netstandard2.0, do not update unless Microsoft (MSDN) says it's possible. -->
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nitrox.BuildTool/Nitrox.BuildTool.csproj
+++ b/Nitrox.BuildTool/Nitrox.BuildTool.csproj
@@ -6,14 +6,15 @@
         <Nullable>disable</Nullable>
         <OutputPath>bin\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mono.Cecil" Version="0.11.4"/>
+        <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\NitroxModel\NitroxModel.csproj"/>
+        <ProjectReference Include="..\NitroxModel\NitroxModel.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Nitrox.BuildTool/Program.cs
+++ b/Nitrox.BuildTool/Program.cs
@@ -24,7 +24,7 @@ namespace Nitrox.BuildTool
 
 #if BELOWZERO
         private const int LEGACY_BRANCH_SUBNAUTICA_VERSION = 49370;
-#else
+#elif SUBNAUTICA
         private const int LEGACY_BRANCH_SUBNAUTICA_VERSION = 68598;
 #endif
 

--- a/Nitrox.BuildTool/Program.cs
+++ b/Nitrox.BuildTool/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -22,7 +22,11 @@ namespace Nitrox.BuildTool
 
         public static string GeneratedOutputDir => Path.Combine(ProcessDir, "generated_files");
 
+#if BELOWZERO
+        private const int LEGACY_BRANCH_SUBNAUTICA_VERSION = 49370;
+#else
         private const int LEGACY_BRANCH_SUBNAUTICA_VERSION = 68598;
+#endif
 
         public static async Task Main(string[] args)
         {
@@ -58,7 +62,11 @@ namespace Nitrox.BuildTool
 
         private static void AbortIfInvalidGameVersion(GameInstallData game)
         {
+#if BELOWZERO
+            string gameVersionFile = Path.Combine(game.InstallDir, "SubnauticaZero_Data", "StreamingAssets", "SNUnmanagedData", "plastic_status.ignore");
+#elif SUBNAUTICA
             string gameVersionFile = Path.Combine(game.InstallDir, "Subnautica_Data", "StreamingAssets", "SNUnmanagedData", "plastic_status.ignore");
+#endif
             if (!File.Exists(gameVersionFile))
             {
                 return;

--- a/Nitrox.Test/Nitrox.Test.csproj
+++ b/Nitrox.Test/Nitrox.Test.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
+++ b/Nitrox.Test/Server/Serialization/WorldPersistenceTest.cs
@@ -122,8 +122,10 @@ public class WorldPersistenceTest
     private static void StoryTimingTest(StoryTimingData storyTiming, StoryTimingData storyTimingAfter)
     {
         Assert.AreEqual(storyTiming.ElapsedSeconds, storyTimingAfter.ElapsedSeconds);
+#if SUBNAUTICA
         Assert.AreEqual(storyTiming.AuroraCountdownTime, storyTimingAfter.AuroraCountdownTime);
         Assert.AreEqual(storyTiming.AuroraWarningTime, storyTimingAfter.AuroraWarningTime);
+#endif
     }
 
     [DataTestMethod, DynamicWorldDataAfter]
@@ -216,7 +218,9 @@ public class WorldPersistenceTest
             Assert.AreEqual(playerData.CurrentStats.Health, playerDataAfter.CurrentStats.Health);
             Assert.AreEqual(playerData.CurrentStats.Food, playerDataAfter.CurrentStats.Food);
             Assert.AreEqual(playerData.CurrentStats.Water, playerDataAfter.CurrentStats.Water);
+#if SUBNAUTICA
             Assert.AreEqual(playerData.CurrentStats.InfectionAmount, playerDataAfter.CurrentStats.InfectionAmount);
+#endif
 
             Assert.AreEqual(playerData.SubRootId, playerDataAfter.SubRootId);
             Assert.AreEqual(playerData.Permissions, playerDataAfter.Permissions);

--- a/Nitrox.sln
+++ b/Nitrox.sln
@@ -30,62 +30,104 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nitrox.Test", "Nitrox.Test\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Nitrox.Assets.Subnautica", "Nitrox.Assets.Subnautica\Nitrox.Assets.Subnautica.shproj", "{79E92B6D-5D25-4254-AC9F-FA9A1CD3CBC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nitrox.Analyzers", "Nitrox.Analyzers\Nitrox.Analyzers.csproj", "{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nitrox.Analyzers", "Nitrox.Analyzers\Nitrox.Analyzers.csproj", "{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Nitrox.Assets.Subnautica\Nitrox.Assets.Subnautica.projitems*{79e92b6d-5d25-4254-ac9f-fa9a1cd3cbc6}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		BelowZero|Any CPU = BelowZero|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Subnautica|Any CPU = Subnautica|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{CB7FAEFC-D9C0-40B8-A6D5-8B284683E79E}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{EBEBC7DC-FAE3-4FBC-BDD3-38ED8FC072D9}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{59EB8953-864F-4147-A210-7FC97E1A5294}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{59EB8953-864F-4147-A210-7FC97E1A5294}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{59EB8953-864F-4147-A210-7FC97E1A5294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{59EB8953-864F-4147-A210-7FC97E1A5294}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59EB8953-864F-4147-A210-7FC97E1A5294}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59EB8953-864F-4147-A210-7FC97E1A5294}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59EB8953-864F-4147-A210-7FC97E1A5294}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{59EB8953-864F-4147-A210-7FC97E1A5294}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{39E377AD-2163-4428-952D-EBECD402C8F3}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{39E377AD-2163-4428-952D-EBECD402C8F3}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{39E377AD-2163-4428-952D-EBECD402C8F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{39E377AD-2163-4428-952D-EBECD402C8F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{39E377AD-2163-4428-952D-EBECD402C8F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{39E377AD-2163-4428-952D-EBECD402C8F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39E377AD-2163-4428-952D-EBECD402C8F3}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{39E377AD-2163-4428-952D-EBECD402C8F3}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{47D774E0-750C-427B-8C38-F8F985114A2E}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{47D774E0-750C-427B-8C38-F8F985114A2E}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{47D774E0-750C-427B-8C38-F8F985114A2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{47D774E0-750C-427B-8C38-F8F985114A2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{47D774E0-750C-427B-8C38-F8F985114A2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47D774E0-750C-427B-8C38-F8F985114A2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47D774E0-750C-427B-8C38-F8F985114A2E}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{47D774E0-750C-427B-8C38-F8F985114A2E}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{5453E724-5A8B-46A4-850B-1F17FA2E938D}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{77692FDB-F713-41F1-B2AB-9019457B8909}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{77692FDB-F713-41F1-B2AB-9019457B8909}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{77692FDB-F713-41F1-B2AB-9019457B8909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{77692FDB-F713-41F1-B2AB-9019457B8909}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77692FDB-F713-41F1-B2AB-9019457B8909}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77692FDB-F713-41F1-B2AB-9019457B8909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77692FDB-F713-41F1-B2AB-9019457B8909}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{77692FDB-F713-41F1-B2AB-9019457B8909}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{0CD6846B-EDA6-4FFD-A540-2A46CC1074BF}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{E4D8C360-34E4-4BE6-909F-3791DD9169B5}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
+		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.BelowZero|Any CPU.ActiveCfg = BelowZero|Any CPU
+		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.BelowZero|Any CPU.Build.0 = BelowZero|Any CPU
 		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Subnautica|Any CPU.ActiveCfg = Subnautica|Any CPU
+		{EB99BD64-EF43-4B06-BBFB-EB5DFA96E55D}.Subnautica|Any CPU.Build.0 = Subnautica|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AC56EA37-FBBC-4D19-8796-29A42A2331A2}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Nitrox.Assets.Subnautica\Nitrox.Assets.Subnautica.projitems*{79e92b6d-5d25-4254-ac9f-fa9a1cd3cbc6}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/NitroxClient/Communication/Packets/Processors/AuroraAndTimeUpdateProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/AuroraAndTimeUpdateProcessor.cs
@@ -16,10 +16,12 @@ public class AuroraAndTimeUpdateProcessor : ClientPacketProcessor<AuroraAndTimeU
     public override void Process(AuroraAndTimeUpdate packet)
     {
         timeManager.ProcessUpdate(packet.TimeData.TimePacket);
+#if SUBNAUTICA
         StoryManager.UpdateAuroraData(packet.TimeData.AuroraEventData);
         if (packet.Restore)
         {
             StoryManager.RestoreAurora();
         }
+#endif
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/EscapePodChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/EscapePodChangedProcessor.cs
@@ -1,4 +1,5 @@
-﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+#if SUBNAUTICA
+using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.DataStructures.Util;
@@ -35,5 +36,4 @@ namespace NitroxClient.Communication.Packets.Processors
         }
     }
 }
-
-
+#endif

--- a/NitroxClient/Communication/Packets/Processors/GameModeChangedProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/GameModeChangedProcessor.cs
@@ -1,4 +1,4 @@
-﻿using NitroxClient.Communication.Packets.Processors.Abstract;
+using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxModel.Packets;
 
 namespace NitroxClient.Communication.Packets.Processors
@@ -7,7 +7,11 @@ namespace NitroxClient.Communication.Packets.Processors
     {
         public override void Process(GameModeChanged packet)
         {
+#if SUBNAUTICA
             GameModeUtils.SetGameMode((GameModeOption)(int)packet.GameMode, GameModeOption.None);
+#elif BELOWZERO
+            GameModeManager.SetGameOptions((GameModePresetId)(int)packet.GameMode);
+#endif
         }
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/PDAEncyclopediaEntryAddProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PDAEncyclopediaEntryAddProcessor.cs
@@ -17,7 +17,11 @@ public class PDAEncyclopediaEntryAddProcessor : ClientPacketProcessor<PDAEncyclo
     {
         using (PacketSuppressor<PDAEncyclopediaEntryAdd>.Suppress())
         {
+#if SUBNAUTICA
             PDAEncyclopedia.Add(packet.Key, packet.Verbose);
+#elif BELOWZERO
+            PDAEncyclopedia.Add(packet.Key, packet.Verbose, packet.PostNotification);
+#endif
         }
     }
 }

--- a/NitroxClient/Communication/Packets/Processors/PDALogEntryAddProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/PDALogEntryAddProcessor.cs
@@ -1,4 +1,4 @@
-﻿using NitroxClient.Communication.Abstract;
+using NitroxClient.Communication.Abstract;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxModel.Packets;
 
@@ -17,7 +17,11 @@ namespace NitroxClient.Communication.Packets.Processors
         {
             using (PacketSuppressor<PDALogEntryAdd>.Suppress())
             {
+#if SUBNAUTICA
                 PDALog.Add(packet.Key);
+#elif BELOWZERO
+                PDALog.Add(packet.Key, true);
+#endif
             }
         }
     }

--- a/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleDockingProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
@@ -25,7 +25,7 @@ namespace NitroxClient.Communication.Packets.Processors
         {
             GameObject vehicleGo = NitroxEntity.RequireObjectFrom(packet.VehicleId);
             GameObject vehicleDockingBayGo = NitroxEntity.RequireObjectFrom(packet.DockId);
-
+#if SUBNAUTICA
             Vehicle vehicle = vehicleGo.RequireComponent<Vehicle>();
             VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponent<VehicleDockingBay>();
 
@@ -36,15 +36,35 @@ namespace NitroxClient.Communication.Packets.Processors
                 vehicle.GetComponent<MultiplayerVehicleControl>().Exit();
             }
             vehicle.StartCoroutine(DelayAnimationAndDisablePiloting(vehicle, vehicleDockingBay, packet.VehicleId, packet.PlayerId));
+#elif BELOWZERO
+            Dockable dockable = vehicleGo.RequireComponent<Dockable>();
+            VehicleDockingBay vehicleDockingBay = vehicleDockingBayGo.RequireComponent<VehicleDockingBay>();
+
+            using (PacketSuppressor<VehicleDocking>.Suppress())
+            {
+                Log.Debug($"Set docked for {vehicleDockingBay.gameObject.name}");
+                dockable.GetComponent<MultiplayerVehicleControl>().SetPositionVelocityRotation(dockable.transform.position, Vector3.zero, dockable.transform.rotation, Vector3.zero);
+                dockable.GetComponent<MultiplayerVehicleControl>().Exit();
+            }
+            dockable.StartCoroutine(DelayAnimationAndDisablePiloting(dockable, vehicleDockingBay, packet.VehicleId, packet.PlayerId));
+#endif
         }
 
+#if SUBNAUTICA
         IEnumerator DelayAnimationAndDisablePiloting(Vehicle vehicle, VehicleDockingBay vehicleDockingBay, NitroxId vehicleId, ushort playerId)
+#elif BELOWZERO
+        IEnumerator DelayAnimationAndDisablePiloting(Dockable vehicle, VehicleDockingBay vehicleDockingBay, NitroxId vehicleId, ushort playerId)
+#endif
         {
             yield return Yielders.WaitFor1Second;
             // DockVehicle sets the rigid body kinematic of the vehicle to true, we don't want that behaviour
             // Therefore disable kinematic (again) to remove the bouncing behavior
+#if SUBNAUTICA
             vehicleDockingBay.DockVehicle(vehicle);
             vehicle.useRigidbody.isKinematic = false;
+#elif BELOWZERO
+            vehicleDockingBay.Dock(vehicle);
+#endif
             yield return Yielders.WaitFor2Seconds;
             vehicles.SetOnPilotMode(vehicleId, playerId, false);
             if (!vehicle.docked)

--- a/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleUndockingProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.Communication.Packets.Processors.Abstract;
 using NitroxClient.GameLogic;
@@ -58,7 +58,9 @@ namespace NitroxClient.Communication.Packets.Processors
                 // It can happen that the player turns in circles around himself in the vehicle. This stops it.
                 playerInstance.RigidBody.angularVelocity = Vector3.zero;
                 playerInstance.ArmsController.SetWorldIKTarget(vehicle.leftHandPlug, vehicle.rightHandPlug);
+#if SUBNAUTICA
                 playerInstance.AnimationController["in_seamoth"] = vehicle is SeaMoth;
+#endif
                 playerInstance.AnimationController["in_exosuit"] = playerInstance.AnimationController["using_mechsuit"] = vehicle is Exosuit;
                 vehicles.SetOnPilotMode(packet.VehicleId, packet.PlayerId, true);
                 playerInstance.AnimationController.UpdatePlayerAnimations = false;
@@ -69,7 +71,11 @@ namespace NitroxClient.Communication.Packets.Processors
         public IEnumerator StartUndockingAnimation(VehicleDockingBay vehicleDockingBay)
         {
             yield return Yielders.WaitFor2Seconds;
+#if SUBNAUTICA
             vehicleDockingBay.vehicle_docked_param = false;
+#elif BELOWZERO
+            vehicleDockingBay.docked_param = false;
+#endif
         }
 
         private void FinishVehicleUndocking(VehicleUndocking packet, Vehicle vehicle, VehicleDockingBay vehicleDockingBay)
@@ -78,7 +84,11 @@ namespace NitroxClient.Communication.Packets.Processors
             {
                 vehicleDockingBay.SetVehicleUndocked();
             }
+#if SUBNAUTICA
             vehicleDockingBay.dockedVehicle = null;
+#elif BELOWZERO
+            vehicleDockingBay.dockedObject = null;
+#endif
             vehicleDockingBay.CancelInvoke("RepairVehicle");
             vehicle.docked = false;
             Optional<RemotePlayer> player = remotePlayerManager.Find(packet.PlayerId);

--- a/NitroxClient/GameLogic/HUD/NitroxPDATabManager.cs
+++ b/NitroxClient/GameLogic/HUD/NitroxPDATabManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace NitroxClient.GameLogic.HUD;
 
@@ -6,7 +7,7 @@ public class NitroxPDATabManager
 {
     public readonly Dictionary<PDATab, NitroxPDATab> CustomTabs = new();
     
-    private readonly Dictionary<string, Atlas.Sprite> tabSpritesByName = new();
+    private readonly Dictionary<string, Sprite> tabSpritesByName = new();
     private readonly Dictionary<string, TabSpriteLoadedEvent> spriteLoadedCallbackByName = new();
 
     public NitroxPDATabManager()
@@ -19,7 +20,7 @@ public class NitroxPDATabManager
         RegisterTab(new PlayerListTab());
     }
 
-    public void AddTabSprite(string spriteName, Atlas.Sprite sprite)
+    public void AddTabSprite(string spriteName, Sprite sprite)
     {
         tabSpritesByName.Add(spriteName, sprite);
         if (spriteLoadedCallbackByName.TryGetValue(spriteName, out TabSpriteLoadedEvent spriteLoadedEvent))
@@ -29,9 +30,9 @@ public class NitroxPDATabManager
         }
     }
     
-    public bool TryGetTabSprite(string spriteName, out Atlas.Sprite sprite) => tabSpritesByName.TryGetValue(spriteName, out sprite);
+    public bool TryGetTabSprite(string spriteName, out Sprite sprite) => tabSpritesByName.TryGetValue(spriteName, out sprite);
 
-    public delegate void TabSpriteLoadedEvent(Atlas.Sprite sprite);
+    public delegate void TabSpriteLoadedEvent(Sprite sprite);
     
     public void SetSpriteLoadedCallback(string tabName, TabSpriteLoadedEvent callback)
     {

--- a/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PdaTabs/uGUI_PlayerListTab.cs
@@ -75,7 +75,7 @@ public class uGUI_PlayerListTab : uGUI_PingTab
             {
                 if (asset.name.Equals("player_list_tab@3x"))
                 {
-                    nitroxPDATabManager.AddTabSprite(asset.name, new Atlas.Sprite(sprite));
+                    nitroxPDATabManager.AddTabSprite(asset.name, Sprite.Create(sprite.texture, sprite.rect, sprite.pivot, sprite.pixelsPerUnit));
                 }
                 assets.Add(asset.name, sprite);
             }

--- a/NitroxClient/GameLogic/HUD/PlayerListTab.cs
+++ b/NitroxClient/GameLogic/HUD/PlayerListTab.cs
@@ -14,8 +14,11 @@ public class PlayerListTab : NitroxPDATab
     public override PDATab FallbackTabIcon => PDATab.Inventory;
 
     public override uGUI_PDATab uGUI_PDATab => tab;
-
+#if SUBNAUTICA
     public override PDATab PDATabId => (PDATab)8;
+#elif BELOWZERO
+    public override PDATab PDATabId => (PDATab)9;
+#endif
 
     public override void OnInitializePDA(uGUI_PDA uGUI_PDA)
     {

--- a/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PdaInitialSyncProcessor.cs
@@ -67,7 +67,11 @@ public class PdaInitialSyncProcessor : InitialSyncProcessor
             // We don't do as in PDAEncyclopedia.Deserialize because we don't persist the entry's fields which are useless
             foreach (string entry in entries)
             {
-                PDAEncyclopedia.Add(entry, false);
+#if SUBNAUTICA
+                    PDAEncyclopedia.Add(entry, false);
+#elif BELOWZERO
+                PDAEncyclopedia.Add(entry, false, false);
+#endif
             }
         }
         yield break;

--- a/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerInitialSyncProcessor.cs
@@ -81,6 +81,7 @@ namespace NitroxClient.GameLogic.InitialSync
                 Player.main.liveMixin.health = statsData.Health;
                 Player.main.GetComponent<Survival>().food = statsData.Food;
                 Player.main.GetComponent<Survival>().water = statsData.Water;
+#if SUBNAUTICA
                 Player.main.infectedMixin.SetInfectedAmount(statsData.InfectionAmount);
 
                 //If InfectionAmount is at least 1f then the infection reveal should have happened already.
@@ -89,7 +90,7 @@ namespace NitroxClient.GameLogic.InitialSync
                 {
                     Player.main.infectionRevealed = true;
                 }
-
+#endif
                 // We need to make the player invincible before he finishes loading because in some cases he will eventually die before loading
                 Player.main.liveMixin.invincible = true;
                 Player.main.FreezeStats();
@@ -102,7 +103,11 @@ namespace NitroxClient.GameLogic.InitialSync
         private void SetPlayerGameMode(ServerGameMode gameMode)
         {
             Log.Info($"Received initial sync packet with gamemode {gameMode}");
+#if SUBNAUTICA
             GameModeUtils.SetGameMode((GameModeOption)(int)gameMode, GameModeOption.None);
+#elif BELOWZERO
+            GameModeManager.SetGameOptions((GameModePresetId)(int)gameMode);
+#endif
         }
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/PlayerPositionInitialSyncProcessor.cs
@@ -31,8 +31,9 @@ namespace NitroxClient.GameLogic.InitialSync
         {
             // We freeze the player so that he doesn't fall before the cells around him have loaded
             Player.main.cinematicModeActive = true;
-
+#if SUBNAUTICA
             AttachPlayerToEscapePod(packet.AssignedEscapePodId);
+#endif
 
             Vector3 position = packet.PlayerSpawnData.ToUnity();
             Quaternion rotation = packet.PlayerSpawnRotation.ToUnity();
@@ -41,12 +42,13 @@ namespace NitroxClient.GameLogic.InitialSync
                 position = Player.mainObject.transform.position;
             }
             Player.main.SetPosition(position, rotation);
-
+#if SUBNAUTICA
             // Player.Update is setting SubRootID to null after Player position is set
             using (PacketSuppressor<EscapePodChanged>.Suppress())
             {
                 Player.main.ValidateEscapePod();
             }
+#endif
 
             // Player position is relative to a subroot if in a subroot
             Optional<NitroxId> subRootId = packet.PlayerSubRootId;
@@ -70,8 +72,11 @@ namespace NitroxClient.GameLogic.InitialSync
                 yield return Terrain.WaitForWorldLoad();
                 yield break;
             }
-
+#if SUBNAUTICA
             Player.main.SetCurrentSub(subRoot, true);
+#elif BELOWZERO
+            Player.main.SetCurrentSub(subRoot);
+#endif
             if (subRoot.isBase)
             {
                 // If the player's in a base, we don't need to wait for the world to load
@@ -87,7 +92,7 @@ namespace NitroxClient.GameLogic.InitialSync
             Player.main.cinematicModeActive = false;
             Player.main.UpdateIsUnderwater();
         }
-
+#if SUBNAUTICA
         private void AttachPlayerToEscapePod(NitroxId escapePodId)
         {
             GameObject escapePod = NitroxEntity.RequireObjectFrom(escapePodId);
@@ -100,6 +105,7 @@ namespace NitroxClient.GameLogic.InitialSync
 
             Player.main.currentEscapePod = escapePod.GetComponent<EscapePod>();
         }
+#endif
 
     }
 }

--- a/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
+++ b/NitroxClient/GameLogic/InitialSync/StoryGoalInitialSyncProcessor.cs
@@ -20,7 +20,9 @@ public class StoryGoalInitialSyncProcessor : InitialSyncProcessor
             SetTimeData(packet),
             SetupStoryGoalManager(packet),
             SetupTrackers(packet),
+#if SUBNAUTICA
             SetupAuroraAndSunbeam(packet),
+#endif
             SetScheduledGoals(packet),
             RefreshWithLatestData()
         };
@@ -100,7 +102,7 @@ public class StoryGoalInitialSyncProcessor : InitialSyncProcessor
         techTypesToRemove.ForEach(techType => storyGoalManager.itemGoalTracker.goals.Remove(techType));
         yield break;
     }
-
+#if SUBNAUTICA
     // Must happen after CompletedGoals
     private IEnumerator SetupAuroraAndSunbeam(InitialPlayerSync packet)
     {
@@ -126,6 +128,7 @@ public class StoryGoalInitialSyncProcessor : InitialSyncProcessor
 
         yield break;
     }
+#endif
 
     // Must happen after CompletedGoals
     private IEnumerator SetScheduledGoals(InitialPlayerSync packet)

--- a/NitroxClient/GameLogic/LiveMixinManager.cs
+++ b/NitroxClient/GameLogic/LiveMixinManager.cs
@@ -46,8 +46,13 @@ namespace NitroxClient.GameLogic
 
                 if (vehicleDockingBay && dealerVehicle)
                 {
+#if SUBNAUTICA
                     if (vehicleDockingBay.GetDockedVehicle() == dealerVehicle || vehicleDockingBay.interpolatingVehicle == dealerVehicle
                         || vehicleDockingBay.nearbyVehicle == dealerVehicle)
+#elif BELOWZERO
+                    if (vehicleDockingBay.GetDockedObject().vehicle == dealerVehicle || vehicleDockingBay.interpolatingDockable.vehicle == dealerVehicle
+                                                                                     || vehicleDockingBay.nearbyDockable.vehicle == dealerVehicle)
+#endif
                     {
                         Log.Debug($"Dealer {dealer} is vehicle and currently docked or nearby {reciever}, do not harm it!");
                         return false;

--- a/NitroxClient/GameLogic/LocalPlayer.cs
+++ b/NitroxClient/GameLogic/LocalPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NitroxClient.Communication.Abstract;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel;
 using NitroxClient.GameLogic.PlayerLogic.PlayerModel.Abstract;
@@ -65,9 +65,11 @@ namespace NitroxClient.GameLogic
         }
 
         public void AnimationChange(AnimChangeType type, AnimChangeState state) => packetSender.Send(new AnimationChangeEvent(multiplayerSession.Reservation.PlayerId, (int)type, (int)state));
-
+#if SUBNAUTICA
         public void BroadcastStats(float oxygen, float maxOxygen, float health, float food, float water, float infectionAmount) => packetSender.Send(new PlayerStats(multiplayerSession.Reservation.PlayerId, oxygen, maxOxygen, health, food, water, infectionAmount));
-
+#elif BELOWZERO
+        public void BroadcastStats(float oxygen, float maxOxygen, float health, float food, float water) => packetSender.Send(new PlayerStats(multiplayerSession.Reservation.PlayerId, oxygen, maxOxygen, health, food, water));
+#endif
         public void BroadcastDeath(Vector3 deathPosition) => packetSender.Send(new PlayerDeathEvent(multiplayerSession.Reservation.PlayerId, deathPosition.ToDto()));
 
         public void BroadcastSubrootChange(Optional<NitroxId> subrootId) => packetSender.Send(new SubRootChanged(multiplayerSession.Reservation.PlayerId, subrootId));
@@ -85,9 +87,15 @@ namespace NitroxClient.GameLogic
             GameObject prototype = Body;
 
             // Cheap fix for showing head, much easier since male_geo contains many different heads
+#if SUBNAUTICA
             prototype.GetComponentInParent<Player>().head.shadowCastingMode = ShadowCastingMode.On;
             GameObject clone = Object.Instantiate(prototype, Multiplayer.Main.transform, false);
             prototype.GetComponentInParent<Player>().head.shadowCastingMode = ShadowCastingMode.ShadowsOnly;
+#elif BELOWZERO
+            prototype.GetComponentInParent<Player>().staticHead.shadowCastingMode = ShadowCastingMode.On;
+            GameObject clone = Object.Instantiate(prototype);
+            prototype.GetComponentInParent<Player>().staticHead.shadowCastingMode = ShadowCastingMode.ShadowsOnly;
+#endif
 
             clone.SetActive(false);
             clone.name = "RemotePlayerPrototype";

--- a/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
+++ b/NitroxClient/GameLogic/PlayerLogic/PlayerModel/PlayerModelManager.cs
@@ -72,7 +72,11 @@ public class PlayerModelManager
         signalBase.SetActive(true);
 
         PingInstance ping = signalBase.GetComponent<PingInstance>();
+#if SUBNAUTICA
         ping.Initialize();
+#elif BELOWZERO
+        ping.Start();
+#endif
         ping.SetLabel($"Player {player.PlayerName}");
         ping.pingType = PingType.Signal;
         // ping will be moved to the player list tab

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -35,7 +35,9 @@ namespace NitroxClient.GameLogic
 
         public Vehicle Vehicle { get; private set; }
         public SubRoot SubRoot { get; private set; }
+#if SUBNAUTICA
         public EscapePod EscapePod { get; private set; }
+#endif
         public PilotingChair PilotingChair { get; private set; }
 
         public readonly Event<RemotePlayer> PlayerDeathEvent = new();
@@ -182,7 +184,7 @@ namespace NitroxClient.GameLogic
                 SubRoot = newSubRoot;
             }
         }
-
+#if SUBNAUTICA
         public void SetEscapePod(EscapePod newEscapePod)
         {
             if (EscapePod != newEscapePod)
@@ -199,6 +201,7 @@ namespace NitroxClient.GameLogic
                 EscapePod = newEscapePod;
             }
         }
+#endif
 
         public void SetVehicle(Vehicle newVehicle)
         {

--- a/NitroxClient/GameLogic/Spawning/Metadata/RepairedComponentMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/RepairedComponentMetadataProcessor.cs
@@ -14,7 +14,7 @@ public class RepairedComponentMetadataProcessor : GenericEntityMetadataProcessor
             radio.liveMixin.health = radio.liveMixin.maxHealth;
             radio.repairNotification.Play();
         }
-
+#if SUBNAUTICA
         EscapePod pod = gameObject.GetComponent<EscapePod>();
 
         if (pod)
@@ -24,5 +24,6 @@ public class RepairedComponentMetadataProcessor : GenericEntityMetadataProcessor
             pod.fixPanelGoal.Trigger();
             pod.fixPanelPowerUp.Play();
         }
+#endif
     }
 }

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/EscapePodWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/EscapePodWorldEntitySpawner.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using System.Collections;
 using NitroxClient.GameLogic.Spawning.Metadata;
 using NitroxClient.MonoBehaviours;
@@ -95,3 +96,4 @@ namespace NitroxClient.GameLogic.Spawning.WorldEntities
     }
 
 }
+#endif

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/PlayerWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/PlayerWorldEntitySpawner.cs
@@ -77,6 +77,7 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
             Log.Debug($"Found sub root for {remotePlayer.PlayerName}. Will add him and update animation.");
             remotePlayer.SetSubRoot(subRoot);
         }
+#if SUBNAUTICA
         else if (parent.TryGetComponent(out EscapePod escapePod))
         {
             Log.Debug($"Found EscapePod for {remotePlayer.PlayerName}.");
@@ -85,7 +86,13 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
         else
         {
             Log.Error($"Found neither SubRoot component nor EscapePod on {parent.name} for {remotePlayer.PlayerName}.");
-        }        
+        }  
+#elif BELOWZERO
+        else
+        {
+            Log.Error($"Could not find SubRoot component on {parent.name} for {remotePlayer.PlayerName}.");
+        }
+#endif
     }
 
     private bool IsSwimming(Vector3 playerPosition, Optional<GameObject> parent)
@@ -122,7 +129,7 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
                     return false;
                 }
             }
-
+#if SUBNAUTICA
             Log.Debug($"Trying to find escape pod for {parent}.");
             parent.Value.TryGetComponent<EscapePod>(out EscapePod escapePod);
             if (escapePod)
@@ -130,6 +137,7 @@ public class PlayerWorldEntitySpawner : IWorldEntitySpawner
                 Log.Debug("Found escape pod for player. Will add him and update animation.");
                 return false;
             }
+#endif
         }
 
         // Player can be above ocean level.

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/VehicleWorldEntitySpawner.cs
@@ -164,7 +164,11 @@ public class VehicleWorldEntitySpawner : IWorldEntitySpawner
 
     private void DockVehicle(GameObject gameObject, GameObject parent)
     {
+#if SUBNAUTICA
         Vehicle vehicle = gameObject.GetComponent<Vehicle>();
+#elif BELOWZERO
+        Dockable vehicle = gameObject.GetComponent<Dockable>();
+#endif
 
         if (!vehicle)
         {
@@ -179,8 +183,11 @@ public class VehicleWorldEntitySpawner : IWorldEntitySpawner
             Log.Info($"Could not find VehicleDockingBay component on dock object {parent.name}");
             return;
         }
-
-        dockingBay.DockVehicle(vehicle);        
+#if SUBNAUTICA
+        dockingBay.DockVehicle(vehicle);
+#elif BELOWZERO
+        dockingBay.Dock(vehicle);
+#endif
     }
 
     public bool SpawnsOwnChildren()

--- a/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
+++ b/NitroxClient/GameLogic/Spawning/WorldEntities/WorldEntitySpawnerResolver.cs
@@ -18,8 +18,10 @@ public class WorldEntitySpawnerResolver
     public WorldEntitySpawnerResolver(PlayerManager playerManager, ILocalNitroxPlayer localPlayer)
     {
         customSpawnersByTechType[TechType.Crash] = new CrashEntitySpawner();
+#if SUBNAUTICA
         customSpawnersByTechType[TechType.Reefback] = new ReefbackWorldEntitySpawner(defaultEntitySpawner);
         customSpawnersByTechType[TechType.EscapePod] = new EscapePodWorldEntitySpawner();
+#endif
         prefabWorldEntitySpawner = new PlaceholderGroupWorldEntitySpawner(this, defaultEntitySpawner);
         playerWorldEntitySpawner = new PlayerWorldEntitySpawner(playerManager, localPlayer);
     }

--- a/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
+++ b/NitroxClient/MonoBehaviours/Gui/MainMenu/JoinServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
@@ -212,7 +212,11 @@ public class JoinServer : MonoBehaviour
 
 #pragma warning disable CS0618 // God Damn it UWE...
                 Multiplayer.SubnauticaLoadingStarted();
+#if SUBNAUTICA
                 IEnumerator startNewGame = uGUI_MainMenu.main.StartNewGame(GameMode.Survival);
+#elif BELOWZERO
+                IEnumerator startNewGame = uGUI_MainMenu.main.StartNewGame(GameModePresetId.Survival);
+#endif
 #pragma warning restore CS0618 // God damn it UWE...
                 StartCoroutine(startNewGame);
                 LoadingScreenVersionText.Initialize();

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -183,9 +183,14 @@ namespace NitroxClient.MonoBehaviours
 
         private static void SetLoadingComplete()
         {
+#if SUBNAUTICA
             WaitScreen.main.isWaiting = false;
             WaitScreen.main.stageProgress.Clear();
             FreezeTime.End(FreezeTime.Id.WaitScreen);
+#elif BELOWZERO
+            WaitScreen.main.Hide();
+#endif
+            
             WaitScreen.main.items.Clear();
 
             PlayerManager remotePlayerManager = NitroxServiceLocator.LocateService<PlayerManager>();

--- a/NitroxClient/MonoBehaviours/MultiplayerExosuit.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerExosuit.cs
@@ -1,4 +1,4 @@
-﻿using NitroxClient.Unity.Smoothing;
+using NitroxClient.Unity.Smoothing;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours
@@ -31,7 +31,12 @@ namespace NitroxClient.MonoBehaviours
         {
             GetComponent<Rigidbody>().freezeRotation = true;
             exosuit.SetIKEnabled(false);
+#if SUBNAUTICA
             exosuit.loopingJetSound.Stop();
+#elif BELOWZERO
+            exosuit.jumpJetsSound.Stop();
+            exosuit.boostSound.Stop();
+#endif
             exosuit.fxcontrol.Stop(0);
             exosuit.ambienceSound.Stop();
             base.Exit();
@@ -45,12 +50,20 @@ namespace NitroxClient.MonoBehaviours
                 lastThrottle = isOn;
                 if (isOn)
                 {
+#if SUBNAUTICA
                     exosuit.loopingJetSound.Play();
+#elif BELOWZERO
+                    exosuit.boostSound.Play();
+#endif
                     exosuit.fxcontrol.Play(0);
                 }
                 else
                 {
+#if SUBNAUTICA
                     exosuit.loopingJetSound.Stop();
+#elif BELOWZERO
+                    exosuit.boostSound.Stop();
+#endif
                     exosuit.fxcontrol.Stop(0);
                 }
             }

--- a/NitroxClient/MonoBehaviours/Overrides/MultiplayerBuilder.cs
+++ b/NitroxClient/MonoBehaviours/Overrides/MultiplayerBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using FMODUnity;
 using NitroxModel.DataStructures.GameLogic.Buildings.Rotation;
@@ -76,7 +76,11 @@ namespace NitroxClient.MonoBehaviours.Overrides
                 }
 
                 renderers = MaterialExtensions.AssignMaterial(ghostModel, ghostStructureMaterial, true);
+#if SUBNAUTICA
                 string poweredPrefabName = CraftData.GetPoweredPrefabName(constructableTechType);
+#elif BELOWZERO
+                string poweredPrefabName = TechData.GetPoweredPrefabName(constructableTechType);
+#endif
                 if (!string.IsNullOrEmpty(poweredPrefabName))
                 {
                     CoroutineHost.StartCoroutine(CreatePowerPreviewAsync(ghostModel, poweredPrefabName));

--- a/NitroxClient/MonoBehaviours/Overrides/RemotePlayerCinematicController.cs
+++ b/NitroxClient/MonoBehaviours/Overrides/RemotePlayerCinematicController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NitroxClient.GameLogic;
 using UnityEngine;
 using static PlayerCinematicController;
@@ -171,7 +171,11 @@ public class RemotePlayerCinematicController : MonoBehaviour, IManagedUpdateBeha
     private void SetVrActiveParam()
     {
         string paramaterName = "vr_active";
+#if SUBNAUTICA
         bool vrAnimationMode = GameOptions.GetVrAnimationMode();
+#elif BELOWZERO
+        bool vrAnimationMode = VRGameOptions.GetVrAnimationMode();
+#endif
         if (animator != null)
         {
             animator.SetBool(paramaterName, vrAnimationMode);
@@ -192,7 +196,11 @@ public class RemotePlayerCinematicController : MonoBehaviour, IManagedUpdateBeha
 
         if (onlyUseEndTransformInVr)
         {
+#if SUBNAUTICA
             return GameOptions.GetVrAnimationMode();
+#elif BELOWZERO
+            return VRGameOptions.GetVrAnimationMode();
+#endif
         }
 
         return true;
@@ -227,7 +235,11 @@ public class RemotePlayerCinematicController : MonoBehaviour, IManagedUpdateBeha
         if (!cinematicModeActive)
         {
             player = null;
+#if SUBNAUTICA
             if (!playInVr && GameOptions.GetVrAnimationMode())
+#elif BELOWZERO
+            if (!playInVr && VRGameOptions.GetVrAnimationMode())
+#endif
             {
                 if (debug)
                 {
@@ -366,8 +378,11 @@ public class RemotePlayerCinematicController : MonoBehaviour, IManagedUpdateBeha
         {
             transform = player.Body.GetComponent<Transform>();
         }
-
+#if SUBNAUTICA
         bool isVrAnimationMode = !GameOptions.GetVrAnimationMode();
+#elif BELOWZERO
+        bool isVrAnimationMode = !VRGameOptions.GetVrAnimationMode();
+#endif
         switch (state)
         {
             case State.In:

--- a/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovementBroadcaster.cs
@@ -109,12 +109,16 @@ public class PlayerMovementBroadcaster : MonoBehaviour
             // So, we need to hack in and try to figure out when thrust needs to be applied.
             if (vehicle && AvatarInputHandler.main.IsEnabled())
             {
+#if SUBNAUTICA
                 if (techType == TechType.Seamoth)
                 {
                     bool flag = vehicle.transform.position.y < Ocean.GetOceanLevel() && vehicle.transform.position.y < vehicle.worldForces.waterDepth && !vehicle.precursorOutOfWater;
                     appliedThrottle = flag && GameInput.GetMoveDirection().sqrMagnitude > .1f;
                 }
                 else if (techType == TechType.Exosuit)
+#elif BELOWZERO
+                if (techType == TechType.Exosuit)
+#endif
                 {
                     Exosuit exosuit = vehicle as Exosuit;
                     if (exosuit)

--- a/NitroxClient/MonoBehaviours/PlayerStatsBroadcaster.cs
+++ b/NitroxClient/MonoBehaviours/PlayerStatsBroadcaster.cs
@@ -1,4 +1,4 @@
-﻿using NitroxClient.GameLogic;
+using NitroxClient.GameLogic;
 using NitroxModel.Core;
 using UnityEngine;
 
@@ -32,8 +32,12 @@ namespace NitroxClient.MonoBehaviours
                     float health = Player.main.liveMixin.health;
                     float food = survival.food;
                     float water = survival.water;
+#if SUBNAUTICA
                     float infectionAmount = Player.main.infectedMixin.GetInfectedAmount();
                     localPlayer.BroadcastStats(oxygen, maxOxygen, health, food, water, infectionAmount);
+#elif BELOWZERO
+                    localPlayer.BroadcastStats(oxygen, maxOxygen, health, food, water);
+#endif
                 }
             }
         }

--- a/NitroxClient/NitroxClient.csproj
+++ b/NitroxClient/NitroxClient.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NitroxLauncher/Models/Patching/NitroxEntryPatch.cs
+++ b/NitroxLauncher/Models/Patching/NitroxEntryPatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,7 +25,11 @@ namespace NitroxLauncher.Models.Patching
         private const string NITROX_EXECUTE_INSTRUCTION = "System.Void NitroxPatcher.Main::Execute()";
 
         private readonly Func<string> subnauticaBasePathFunc;
+#if SUBNAUTICA
         private string subnauticaManagedPath => Path.Combine(subnauticaBasePathFunc(), "Subnautica_Data", "Managed");
+#elif BELOWZERO
+        private string subnauticaManagedPath => Path.Combine(subnauticaBasePathFunc(), "SubnauticaZero_Data", "Managed");
+#endif
 
         public bool IsApplied => IsPatchApplied();
 

--- a/NitroxLauncher/NitroxLauncher.csproj
+++ b/NitroxLauncher/NitroxLauncher.csproj
@@ -12,6 +12,7 @@
         <Authors>Nitrox</Authors>
         <Company>Nitrox</Company>
         <PackageProjectUrl>https://github.com/SubnauticaNitrox/Nitrox</PackageProjectUrl>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
+++ b/NitroxModel-Subnautica/NitroxModel-Subnautica.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>NitroxModel_Subnautica</RootNamespace>
     <Nullable>disable</Nullable>
+    <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NitroxModel/DataStructures/GameLogic/PlayerStatsData.cs
+++ b/NitroxModel/DataStructures/GameLogic/PlayerStatsData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using BinaryPack.Attributes;
 
@@ -22,28 +22,39 @@ namespace NitroxModel.DataStructures.GameLogic
 
         [DataMember(Order = 5)]
         public float Water { get; }
+#if SUBNAUTICA
         [DataMember(Order = 6)]
         public float InfectionAmount { get; }
+#endif
 
         [IgnoreConstructor]
         protected PlayerStatsData()
         {
             // Constructor for serialization. Has to be "protected" for json serialization.
         }
-
+#if SUBNAUTICA
         public PlayerStatsData(float oxygen, float maxOxygen, float health, float food, float water, float infectionAmount)
+#elif BELOWZERO
+        public PlayerStatsData(float oxygen, float maxOxygen, float health, float food, float water)
+#endif
         {
             Oxygen = oxygen;
             MaxOxygen = maxOxygen;
             Health = health;
             Food = food;
             Water = water;
+#if SUBNAUTICA
             InfectionAmount = infectionAmount;
+#endif
         }
 
         public override string ToString()
         {
+#if SUBNAUTICA
             return $"[Oxygen: {Oxygen} MaxOxygen: {MaxOxygen} Health: {Health} Food: {Food} Water: {Water} InfectionAmount: {InfectionAmount} ]";
+#elif BELOWZERO
+            return $"[Oxygen: {Oxygen} MaxOxygen: {MaxOxygen} Health: {Health} Food: {Food} Water: {Water} ]";
+#endif
         }
     }
 }

--- a/NitroxModel/DataStructures/GameLogic/TimeData.cs
+++ b/NitroxModel/DataStructures/GameLogic/TimeData.cs
@@ -7,6 +7,7 @@ namespace NitroxModel.DataStructures.GameLogic;
 public class TimeData
 {
     public TimeChange TimePacket;
+#if SUBNAUTICA
     public AuroraEventData AuroraEventData;
 
     public TimeData(TimeChange timePacket, AuroraEventData auroraEventData)
@@ -14,4 +15,10 @@ public class TimeData
         TimePacket = timePacket;
         AuroraEventData = auroraEventData;
     }
+#elif BELOWZERO
+    public TimeData(TimeChange timePacket)
+    {
+        TimePacket = timePacket;
+    }
+#endif
 }

--- a/NitroxModel/Discovery/GameInstallationFinder.cs
+++ b/NitroxModel/Discovery/GameInstallationFinder.cs
@@ -51,13 +51,12 @@ namespace NitroxModel.Discovery
             {
                 return false;
             }
-#if SUBNAUTICA
-            return Directory.EnumerateFiles(directory, "*.exe")
-                .Any(file => Path.GetFileName(file)?.Equals("subnautica.exe", StringComparison.OrdinalIgnoreCase) ?? false);
-#endif
 #if BELOWZERO
             return Directory.EnumerateFiles(directory, "*.exe")
                 .Any(file => Path.GetFileName(file)?.Equals("subnauticazero.exe", StringComparison.OrdinalIgnoreCase) ?? false);
+#elif SUBNAUTICA
+            return Directory.EnumerateFiles(directory, "*.exe")
+                .Any(file => Path.GetFileName(file)?.Equals("subnautica.exe", StringComparison.OrdinalIgnoreCase) ?? false);
 #endif
         }
     }

--- a/NitroxModel/Discovery/GameInstallationFinder.cs
+++ b/NitroxModel/Discovery/GameInstallationFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -51,9 +51,14 @@ namespace NitroxModel.Discovery
             {
                 return false;
             }
-
+#if SUBNAUTICA
             return Directory.EnumerateFiles(directory, "*.exe")
                 .Any(file => Path.GetFileName(file)?.Equals("subnautica.exe", StringComparison.OrdinalIgnoreCase) ?? false);
+#endif
+#if BELOWZERO
+            return Directory.EnumerateFiles(directory, "*.exe")
+                .Any(file => Path.GetFileName(file)?.Equals("subnauticazero.exe", StringComparison.OrdinalIgnoreCase) ?? false);
+#endif
         }
     }
 }

--- a/NitroxModel/Discovery/InstallationFinders/ConfigGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/ConfigGameFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using NitroxModel.Helper;
 
@@ -12,6 +12,7 @@ namespace NitroxModel.Discovery.InstallationFinders
         public string FindGame(IList<string> errors = null)
         {
             string path = NitroxUser.PreferredGamePath;
+#if SUBNAUTICA
             if (string.IsNullOrEmpty(path))
             {
                 errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica installation.");
@@ -23,6 +24,20 @@ namespace NitroxModel.Discovery.InstallationFinders
                 errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica installation.");
                 return null;
             }
+#endif
+#if BELOWZERO
+            if (string.IsNullOrEmpty(path))
+            {
+                errors?.Add(@"Configured game path was found empty. Please enter the path to the Subnautica Below Zero installation.");
+                return null;
+            }
+
+            if (!Directory.Exists(Path.Combine(path, "SubnauticaZero_Data", "Managed")))
+            {
+                errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica Below Zero installation.");
+                return null;
+            }
+#endif
 
             return path;
         }

--- a/NitroxModel/Discovery/InstallationFinders/DiscordGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/DiscordGameFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -6,6 +6,7 @@ namespace NitroxModel.Discovery.InstallationFinders
 {
     public class DiscordGameFinder : IFindGameInstallation
     {
+#if SUBNAUTICA
         /// <summary>
         ///     Subnautica Discord is either in appdata or in C:. So for now we just check these 2 paths until we have a better way.
         ///     Discord stores game files in a subfolder called "content" while the parent folder is used to store Discord related files instead.
@@ -30,5 +31,32 @@ namespace NitroxModel.Discovery.InstallationFinders
         {
             return File.Exists(Path.Combine(path, GameInfo.Subnautica.ExeName));
         }
+#endif
+#if BELOWZERO
+        /// <summary>
+        ///     Subnautica Below Zero Discord is either in appdata or in C:. So for now we just check these 2 paths until we have a better way.
+        ///     Discord stores game files in a subfolder called "content" while the parent folder is used to store Discord related files instead.
+        /// </summary>
+        public string FindGame(IList<string> errors = null)
+        {
+            string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DiscordGames", "SubnauticaZero", "content");
+            if (HasSubnautica(path))
+            {
+                return path;
+            }
+            path = @"C:\Games\SubnauticaZero\content";
+            if (HasSubnautica(path))
+            {
+                return path;
+            }
+
+            return null;
+        }
+
+        private bool HasSubnautica(string path)
+        {
+            return File.Exists(Path.Combine(path, GameInfo.SubnauticaBelowZero.ExeName));
+        }
+#endif
     }
 }

--- a/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EnvironmentGameFinder.cs
@@ -11,6 +11,7 @@ public class EnvironmentGameFinder : IFindGameInstallation
 {
     public string FindGame(IList<string> errors = null)
     {
+#if SUBNAUTICA
         string path = Environment.GetEnvironmentVariable("SUBNAUTICA_INSTALLATION_PATH");
         if (string.IsNullOrEmpty(path))
         {
@@ -23,6 +24,21 @@ public class EnvironmentGameFinder : IFindGameInstallation
             errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica installation.");
             return null;
         }
+#endif
+#if BELOWZERO
+        string path = Environment.GetEnvironmentVariable("SUBNAUTICAZERO_INSTALLATION_PATH");
+        if (string.IsNullOrEmpty(path))
+        {
+            errors?.Add(@"Configured game path with environment variable SUBNAUTICAZERO_INSTALLATION_PATH was found empty.");
+            return null;
+        }
+
+        if (!Directory.Exists(Path.Combine(path, "SubnauticaZero_Data", "Managed")))
+        {
+            errors?.Add($@"Game installation directory config '{path}' is invalid. Please enter the path to the Subnautica Below Zero installation.");
+            return null;
+        }
+#endif
 
         return path;
     }

--- a/NitroxModel/Discovery/InstallationFinders/EpicGamesInstallationFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/EpicGamesInstallationFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -23,14 +23,26 @@ namespace NitroxModel.Discovery.InstallationFinders
             {
                 string fileText = File.ReadAllText(file);
                 Match match = installLocationRegex.Match(fileText);
+#if SUBNAUTICA
                 if (match.Success && match.Value.Contains("Subnautica") && !match.Value.Contains("Below"))
+#elif BELOWZERO
+                if (match.Success && match.Value.Contains("Subnautica") && match.Value.Contains("Below"))
+#endif
                 {
+#if SUBNAUTICA
                     Log.Debug($"Found Subnautica install path in '{Path.GetFullPath(file)}'. Full pattern match: '{match.Value}'");
+#elif BELOWZERO
+                    Log.Debug($"Found Subnautica Below Zero install path in '{Path.GetFullPath(file)}'. Full pattern match: '{match.Value}'");
+#endif
                     return match.Groups[1].Value;
                 }
             }
 
+#if SUBNAUTICA
             errors?.Add("Could not find Subnautica installation directory from Epic Games installation records. Verify that Subnautica has been installed with Epic Games Store.");
+#elif BELOWZERO
+            errors?.Add("Could not find Subnautica Below Zero installation directory from Epic Games installation records. Verify that Subnautica Below Zero has been installed with Epic Games Store.");
+#endif
             return null;
         }
     }

--- a/NitroxModel/Discovery/InstallationFinders/GameInCurrentDirectoryFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/GameInCurrentDirectoryFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 
 namespace NitroxModel.Discovery.InstallationFinders
@@ -8,7 +8,12 @@ namespace NitroxModel.Discovery.InstallationFinders
         public string FindGame(IList<string> errors = null)
         {
             string currentDirectory = Directory.GetCurrentDirectory();
+#if SUBNAUTICA
             if (File.Exists(Path.Combine(currentDirectory, "Subnautica.exe")))
+#endif
+#if BELOWZERO
+            if (File.Exists(Path.Combine(currentDirectory, "SubnauticaZero.exe")))
+#endif
             {
                 return currentDirectory;
             }

--- a/NitroxModel/Discovery/InstallationFinders/SteamGameRegistryFinder.cs
+++ b/NitroxModel/Discovery/InstallationFinders/SteamGameRegistryFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -36,6 +36,7 @@ namespace NitroxModel.Discovery.InstallationFinders
                 return null;
             }
             string appsPath = Path.Combine(steamPath, "steamapps");
+#if SUBNAUTICA
             if (File.Exists(Path.Combine(appsPath, $"appmanifest_{GameInfo.Subnautica.SteamAppId}.acf")))
             {
                 return Path.Combine(appsPath, "common", GameInfo.Subnautica.Name);
@@ -49,6 +50,21 @@ namespace NitroxModel.Discovery.InstallationFinders
             {
                 return path;
             }
+#elif BELOWZERO
+            if(File.Exists(Path.Combine(appsPath, $"appmanifest_{GameInfo.SubnauticaBelowZero.SteamAppId}.acf")))
+            {
+                return Path.Combine(appsPath, "common", GameInfo.SubnauticaBelowZero.Name);
+            }
+            string path = SearchAllInstallations(Path.Combine(appsPath, "libraryfolders.vdf"), GameInfo.SubnauticaBelowZero.SteamAppId, GameInfo.SubnauticaBelowZero.Name);
+            if(string.IsNullOrEmpty(path))
+            {
+                errors?.Add($"It appears you don't have {GameInfo.SubnauticaBelowZero.Name} installed anywhere. The game files are needed to run the server");
+            }
+            else
+            {
+                return path;
+            }
+#endif
 
             return null;
         }

--- a/NitroxModel/Helper/PirateDetection.cs
+++ b/NitroxModel/Helper/PirateDetection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using NitroxModel.Platforms.OS.Shared;
 
@@ -42,7 +42,11 @@ namespace NitroxModel.Helper
 
         private static bool IsPirateByDirectory(string subnauticaRoot)
         {
+#if SUBNAUTICA
             string subdirDll = Path.Combine(subnauticaRoot, "Subnautica_Data", "Plugins", "x86_64", "steam_api64.dll");
+#elif BELOWZERO
+            string subdirDll = Path.Combine(subnauticaRoot, "SubnauticaZero_Data", "Plugins", "x86_64", "steam_api64.dll");
+#endif
             if (File.Exists(subdirDll) && !FileSystem.Instance.IsTrustedFile(subdirDll))
             {
                 return true;

--- a/NitroxModel/NitroxModel.csproj
+++ b/NitroxModel/NitroxModel.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <!-- .NET Framework polyfills for modern C# lang support -->

--- a/NitroxModel/Packets/PDAEncyclopediaEntryAdd.cs
+++ b/NitroxModel/Packets/PDAEncyclopediaEntryAdd.cs
@@ -11,9 +11,18 @@ public class PDAEncyclopediaEntryAdd : Packet
     /// </summary>
     public bool Verbose { get; }
 
+#if BELOWZERO
+    public bool PostNotification { get; }
+
+    public PDAEncyclopediaEntryAdd(string key, bool verbose, bool postNotification)
+#elif SUBNAUTICA
     public PDAEncyclopediaEntryAdd(string key, bool verbose)
+#endif
     {
         Key = key;
         Verbose = verbose;
+#if BELOWZERO
+        PostNotification = postNotification;
+#endif
     }
 }

--- a/NitroxModel/Packets/PlayerStats.cs
+++ b/NitroxModel/Packets/PlayerStats.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NitroxModel.Networking;
 
 namespace NitroxModel.Packets
@@ -12,9 +12,13 @@ namespace NitroxModel.Packets
         public float Health { get; }
         public float Food { get; }
         public float Water { get; }
+#if SUBNAUTICA
         public float InfectionAmount { get; }
 
         public PlayerStats(ushort playerId, float oxygen, float maxOxygen, float health, float food, float water, float infectionAmount)
+#elif BELOWZERO
+        public PlayerStats(ushort playerId, float oxygen, float maxOxygen, float health, float food, float water)
+#endif
         {
             PlayerId = playerId;
             Oxygen = oxygen;
@@ -22,7 +26,9 @@ namespace NitroxModel.Packets
             Health = health;
             Food = food;
             Water = water;
+#if SUBNAUTICA
             InfectionAmount = infectionAmount;
+#endif
             DeliveryMethod = NitroxDeliveryMethod.DeliveryMethod.UNRELIABLE_SEQUENCED;
             UdpChannel = UdpChannelId.PLAYER_STATS;
         }

--- a/NitroxModel/Platforms/Store/Steam.cs
+++ b/NitroxModel/Platforms/Store/Steam.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -21,7 +21,12 @@ namespace NitroxModel.Platforms.Store
 
         public bool OwnsGame(string gameDirectory)
         {
+#if SUBNAUTICA
             return File.Exists(Path.Combine(gameDirectory, "Subnautica_Data", "Plugins", "x86_64", "steam_api64.dll"));
+#endif
+#if BELOWZERO
+            return File.Exists(Path.Combine(gameDirectory, "SubnauticaZero_Data", "Plugins", "x86_64", "steam_api64.dll"));
+#endif
         }
 
         public async Task<ProcessEx> StartPlatformAsync()

--- a/NitroxPatcher/NitroxPatcher.csproj
+++ b/NitroxPatcher/NitroxPatcher.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NitroxPatcher/Patches/Dynamic/Builder_TryPlace_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Builder_TryPlace_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -33,9 +33,15 @@ namespace NitroxPatcher.Patches.Dynamic
                      *  Multiplayer.Logic.Building.PlaceBasePiece(componentInParent, component.TargetBase, CraftData.GetTechType(Builder.prefab), Builder.placeRotation);
                      */
                     yield return TranspilerHelper.LocateService<Building>();
+#if SUBNAUTICA
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
                     yield return new CodeInstruction(OpCodes.Ldloc_0);
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
+#elif BELOWZERO
+                    yield return new CodeInstruction(OpCodes.Ldloc_2);
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    yield return new CodeInstruction(OpCodes.Ldloc_2);
+#endif
                     yield return new CodeInstruction(OpCodes.Callvirt, Reflect.Property((BaseGhost t) => t.TargetBase).GetMethod);
                     yield return new CodeInstruction(OpCodes.Ldsfld, Reflect.Field(() => Builder.prefab));
                     yield return new CodeInstruction(OpCodes.Call, Reflect.Method(() => CraftData.GetTechType(default(GameObject))));
@@ -49,7 +55,11 @@ namespace NitroxPatcher.Patches.Dynamic
                      *  Multiplayer.Logic.Building.PlaceFurniture(gameObject, CraftData.GetTechType(Builder.prefab), Builder.ghostModel.transform.position, Builder.placeRotation);
                      */
                     yield return TranspilerHelper.LocateService<Building>();
+#if SUBNAUTICA
                     yield return new CodeInstruction(OpCodes.Ldloc_2);
+#elif BELOWZERO
+                    yield return new CodeInstruction(OpCodes.Ldloc_3);
+#endif
                     yield return new CodeInstruction(OpCodes.Ldsfld, Reflect.Field(() => Builder.prefab));
                     yield return new CodeInstruction(OpCodes.Call, Reflect.Method(() => CraftData.GetTechType(default(GameObject))));
                     yield return new CodeInstruction(OpCodes.Ldsfld, Reflect.Field(() => Builder.ghostModel));

--- a/NitroxPatcher/Patches/Dynamic/DockedVehicleHandTarget_OnHandClick_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/DockedVehicleHandTarget_OnHandClick_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.GameLogic.Simulation;
@@ -17,7 +17,11 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static bool Prefix(DockedVehicleHandTarget __instance, GUIHand hand)
         {
+#if SUBNAUTICA
             Vehicle vehicle = __instance.dockingBay.GetDockedVehicle();
+#elif BELOWZERO
+            Vehicle vehicle = __instance.dockingBay.GetDockedObject().vehicle;
+#endif
 
             if (skipPrefix || vehicle == null)
             {
@@ -46,7 +50,11 @@ namespace NitroxPatcher.Patches.Dynamic
             if (lockAquired)
             {
                 VehicleDockingBay dockingBay = context.Target.dockingBay;
+#if SUBNAUTICA
                 NitroxServiceLocator.LocateService<Vehicles>().BroadcastVehicleUndocking(dockingBay, dockingBay.GetDockedVehicle(), true);
+#elif BELOWZERO
+                NitroxServiceLocator.LocateService<Vehicles>().BroadcastVehicleUndocking(dockingBay, dockingBay.GetDockedObject().vehicle, true);
+#endif
 
                 skipPrefix = true;
                 context.Target.OnHandClick(context.GuiHand);

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_Awake_Patch.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic.Spawning.WorldEntities;
@@ -20,3 +21,4 @@ namespace NitroxPatcher.Patches.Dynamic
         }
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/EscapePod_OnRepair_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/EscapePod_OnRepair_Patch.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
@@ -26,3 +27,4 @@ namespace NitroxPatcher.Patches.Dynamic
         }
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
@@ -23,6 +23,7 @@ public class Inventory_LoseItems_Patch : NitroxPatch, IDynamicPatch
         for (int i = 0; i < codeInstructions.Count; i++)
         {
             CodeInstruction instruction = codeInstructions[i];
+#if SUBNAUTICA
             /* if (this.InternalDropItem(list[i].item, false))
              * becomes:
              * if (Inventory_LoseItems_Patch.DropAndDeleteItem(list[i].item))
@@ -43,6 +44,44 @@ public class Inventory_LoseItems_Patch : NitroxPatch, IDynamicPatch
             {
                 continue;
             }
+#elif BELOWZERO
+            /* if (this.InternalDropItem(inventoryItem.item, false, true))
+             * becomes:
+             * if (Inventory_LoseItems_Patch.DropAndDeleteItem(inventoryItem.item))
+             */
+
+            // Clear some useless lines
+            if (instruction.opcode.Equals(OpCodes.Ldarg_0) &&
+                codeInstructions[i + 1].opcode.Equals(OpCodes.Ldloc_3) &&
+                codeInstructions[i - 1].opcode.Equals(OpCodes.Bne_Un_S))
+            {
+                // We still need to transfer these labels to the following instruction
+                codeInstructions[i + 1].labels.AddRange(instruction.labels);
+                continue;
+            }
+            if (instruction.opcode.Equals(OpCodes.Ldc_I4_1) &&
+                codeInstructions[i + 1].opcode.Equals(OpCodes.Call) &&
+                codeInstructions[i - 2].opcode.Equals(OpCodes.Callvirt))
+            {
+                continue;
+            }
+
+            // Clear some useless lines
+            if (instruction.opcode.Equals(OpCodes.Ldarg_0) &&
+                codeInstructions[i + 1].opcode.Equals(OpCodes.Ldloc_0) &&
+                codeInstructions[i - 1].opcode.Equals(OpCodes.Br))
+            {
+                // We still need to transfer these labels to the following instruction
+                codeInstructions[i + 1].labels.AddRange(instruction.labels);
+                continue;
+            }
+            if (instruction.opcode.Equals(OpCodes.Ldc_I4_0) &&
+                codeInstructions[i + 2].opcode.Equals(OpCodes.Call) &&
+                codeInstructions[i - 1].opcode.Equals(OpCodes.Callvirt))
+            {
+                continue;
+            }
+#endif
 
             // And modify the call instruction
             if (instruction.opcode.Equals(INJECTION_OPCODE) && instruction.operand.Equals(INJECTION_OPERAND))

--- a/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Inventory_LoseItems_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -11,7 +11,11 @@ public class Inventory_LoseItems_Patch : NitroxPatch, IDynamicPatch
     internal static readonly MethodInfo TARGET_METHOD = Reflect.Method((Inventory t) => t.LoseItems());
 
     internal static readonly OpCode INJECTION_OPCODE = OpCodes.Call;
-    internal static readonly object INJECTION_OPERAND = Reflect.Method((Inventory t) => t.InternalDropItem(default, default));
+#if SUBNAUTICA
+    internal static readonly object INJECTION_OPERAND = Reflect.Method((Inventory t) => t.InternalDropItem(default(Pickupable), default(bool)));
+#elif BELOWZERO
+    internal static readonly object INJECTION_OPERAND = Reflect.Method((Inventory t) => t.InternalDropItem(default(Pickupable), default(bool), default(bool)));
+#endif
 
     public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
     {

--- a/NitroxPatcher/Patches/Dynamic/PDAEncyclopedia_Add_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/PDAEncyclopedia_Add_Patch.cs
@@ -9,9 +9,15 @@ namespace NitroxPatcher.Patches.Dynamic;
 
 public class PDAEncyclopedia_Add_Patch : NitroxPatch, IDynamicPatch
 {
-    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => PDAEncyclopedia.Add(default, default, default));
+#if SUBNAUTICA
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => PDAEncyclopedia.Add(default(string), default(PDAEncyclopedia.Entry), default(bool)));
 
     public static void Postfix(string key, bool verbose, PDAEncyclopedia.EntryData __result)
+#elif BELOWZERO
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => PDAEncyclopedia.Add(default(string), default(PDAEncyclopedia.Entry), default(bool), default(bool)));
+
+    public static void Postfix(string key, bool verbose, bool postNotification, PDAEncyclopedia.EntryData __result)
+#endif
     {
         if (!Multiplayer.Main || !Multiplayer.Main.InitialSyncCompleted)
         {
@@ -21,7 +27,11 @@ public class PDAEncyclopedia_Add_Patch : NitroxPatch, IDynamicPatch
         // Is null when it's a duplicate call
         if (__result != null)
         {
+#if SUBNAUTICA
             Resolve<IPacketSender>().Send(new PDAEncyclopediaEntryAdd(key, verbose));
+#elif BELOWZERO
+            Resolve<IPacketSender>().Send(new PDAEncyclopediaEntryAdd(key, verbose, postNotification));
+#endif
         }
     }
 

--- a/NitroxPatcher/Patches/Dynamic/Player_OnKill_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_OnKill_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -11,7 +11,11 @@ namespace NitroxPatcher.Patches.Dynamic
     {
         private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Player t) => t.OnKill(default(DamageType)));
 
+#if SUBNAUTICA
         private static readonly MethodInfo SKIP_METHOD = Reflect.Method(() => GameModeUtils.IsPermadeath());
+#elif BELOWZERO
+        private static readonly MethodInfo SKIP_METHOD = Reflect.Method(() => GameModeManager.GetOption<bool>(GameOption.PermanentDeath));
+#endif
         public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
         {
             List<CodeInstruction> instructionList = instructions.ToList();

--- a/NitroxPatcher/Patches/Dynamic/Player_OnKill_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_OnKill_Patch.cs
@@ -24,20 +24,24 @@ namespace NitroxPatcher.Patches.Dynamic
             * if (GameModeUtils.IsPermadeath())
             * {
             *      SaveLoadManager.main.ClearSlotAsync(SaveLoadManager.main.GetCurrentSlot());
-            *      this.EndGame();
-            *      return;
             * }
             */
             for (int i = 0; i < instructionList.Count; i++)
             {
                 CodeInstruction instr = instructionList[i];
-
+#if SUBNAUTICA
                 if (instr.opcode == OpCodes.Call && instr.operand.Equals(SKIP_METHOD))
                 {
                     CodeInstruction newInstr = new(OpCodes.Ldc_I4_0);
                     newInstr.labels = instr.labels;
                     yield return newInstr;
                 }
+#elif BELOWZERO
+                if (instr.opcode == OpCodes.Call && instr.operand.Equals(SKIP_METHOD))
+                {
+                    continue;
+                }
+#endif
                 else
                 {
                     yield return instr;

--- a/NitroxPatcher/Patches/Dynamic/Player_SetCurrentEscapePod_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_SetCurrentEscapePod_Patch.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
@@ -31,3 +32,4 @@ namespace NitroxPatcher.Patches.Dynamic
         }
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/Player_SetCurrentSub_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Player_SetCurrentSub_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,7 +11,11 @@ namespace NitroxPatcher.Patches.Dynamic
 {
     public class Player_SetCurrentSub_Patch : NitroxPatch, IDynamicPatch
     {
+#if SUBNAUTICA
         private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Player t) => t.SetCurrentSub(default(SubRoot), default(bool)));
+#elif BELOWZERO
+        private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Player t) => t.SetCurrentSub(default(SubRoot)));
+#endif
 
         public static void Prefix(Player __instance, SubRoot sub)
         {

--- a/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SpawnEscapePodSupplies_OnNewBorn_Patch.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 namespace NitroxPatcher.Patches.Dynamic;
 
 using System.Reflection;
@@ -22,3 +23,4 @@ public class SpawnEscapePodSupplies_OnNewBorn_Patch : NitroxPatch, IDynamicPatch
 
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/StoryGoal_Execute_Patch.cs
@@ -11,7 +11,11 @@ namespace NitroxPatcher.Patches.Dynamic;
 
 public class StoryGoal_Execute_Patch : NitroxPatch, IDynamicPatch
 {
-    private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => StoryGoal.Execute(default, default));
+#if SUBNAUTICA
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => StoryGoal.Execute(default(string), default(Story.GoalType)));
+#elif BELOWZERO
+    public static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => StoryGoal.Execute(default(string), default(Story.GoalType), default(bool), default(bool)));
+#endif
 
     /// <summary>
     /// Notifies the server of the execution of StoryGoals (except of PDA type)

--- a/NitroxPatcher/Patches/Dynamic/SubNameInput_OnColorChange_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubNameInput_OnColorChange_Patch.cs
@@ -20,7 +20,7 @@ namespace NitroxPatcher.Patches.Dynamic
                 // prevent this patch from firing when the initial template cyclops loads (happens on game load with living large update).
                 return;
             }
-
+#if SUBNAUTICA
             SubName subname = __instance.target;
             if (subname)
             {
@@ -55,6 +55,11 @@ namespace NitroxPatcher.Patches.Dynamic
                     Log.Error($"[SubNameInput_OnColorChange_Patch] The GameObject {subname.gameObject.name} doesn't have a Vehicle/SubRoot/Rocket component.");
                     return;
                 }
+#elif BELOWZERO
+            ICustomizeable subname = __instance.target;
+            if (subname != null)
+            {
+#endif
 
                 Resolve<Entities>().EntityMetadataChangedThrottled(__instance, subNameInput.Id);
             }

--- a/NitroxPatcher/Patches/Dynamic/SubNameInput_OnNameChange_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/SubNameInput_OnNameChange_Patch.cs
@@ -20,7 +20,7 @@ namespace NitroxPatcher.Patches.Dynamic
                 // prevent this patch from firing when the initial template cyclops loads (happens on game load with living large update).
                 return;
             }
-
+#if SUBNAUTICA
             SubName subname = __instance.target;
             if (subname)
             {
@@ -54,7 +54,11 @@ namespace NitroxPatcher.Patches.Dynamic
                     Log.Error($"[SubNameInput_OnNameChange_Patch] The GameObject {subname.gameObject.name} doesn't have a Vehicle/SubRoot/Rocket component.");
                     return;
                 }
-
+#elif BELOWZERO
+            ICustomizeable subname = __instance.target;
+            if (subname != null)
+            {
+#endif
                 NitroxId subNameInputId = NitroxEntity.GetId(__instance.gameObject);
                 Resolve<Entities>().EntityMetadataChanged(__instance, subNameInputId);
             }

--- a/NitroxPatcher/Patches/Dynamic/Survival_Use_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/Survival_Use_Patch.cs
@@ -14,7 +14,11 @@ namespace NitroxPatcher.Patches.Dynamic;
 /// </summary>
 public class Survival_Use_Patch : NitroxPatch, IDynamicPatch
 {
+#if SUBNAUTICA
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Survival t) => t.Use(default(GameObject)));
+#elif BELOWZERO
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((Survival t) => t.Use(default(GameObject), default(Inventory)));
+#endif
 
     public static void Postfix(bool __result, GameObject useObj)
     {

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnTriggerEnter.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
@@ -11,17 +11,26 @@ namespace NitroxPatcher.Patches.Dynamic
     class VehicleDockingBay_OnTriggerEnter : NitroxPatch, IDynamicPatch
     {
         private static readonly MethodInfo TARGET_METHOD = Reflect.Method((VehicleDockingBay t) => t.OnTriggerEnter(default(Collider)));
+#if SUBNAUTICA
         private static Vehicle prevInterpolatingVehicle;
+#elif BELOWZERO
+        private static Dockable prevInterpolatingDockable;
+#endif
 
         public static bool Prefix(VehicleDockingBay __instance, Collider other)
         {
             Vehicle vehicle = other.GetComponentInParent<Vehicle>();
+#if SUBNAUTICA
             prevInterpolatingVehicle = __instance.interpolatingVehicle;
+#elif BELOWZERO
+            prevInterpolatingDockable = __instance.interpolatingDockable;
+#endif
             return vehicle == null || Resolve<SimulationOwnership>().HasAnyLockType(NitroxEntity.GetId(vehicle.gameObject));
         }
 
         public static void Postfix(VehicleDockingBay __instance)
         {
+#if SUBNAUTICA
             Vehicle interpolatingVehicle = __instance.interpolatingVehicle;
             // Only send data, when interpolatingVehicle changes to avoid multiple packages send
             if (!interpolatingVehicle || interpolatingVehicle == prevInterpolatingVehicle)
@@ -34,6 +43,20 @@ namespace NitroxPatcher.Patches.Dynamic
                 Log.Debug($"Will send vehicle docking for {id}");
                 Resolve<Vehicles>().BroadcastVehicleDocking(__instance, interpolatingVehicle);
             }
+#elif BELOWZERO
+            Dockable interpolatingDockable = __instance.interpolatingDockable;
+            // Only send data, when interpolatingVehicle changes to avoid multiple packages send
+            if (!interpolatingDockable || interpolatingDockable == prevInterpolatingDockable)
+            {
+                return;
+            }
+            NitroxId id = NitroxEntity.GetId(interpolatingDockable.gameObject);
+            if (Resolve<SimulationOwnership>().HasAnyLockType(id))
+            {
+                Log.Debug($"Will send vehicle docking for {id}");
+                Resolve<Vehicles>().BroadcastVehicleDocking(__instance, interpolatingDockable.vehicle);
+            }
+#endif
         }
 
         public override void Patch(Harmony harmony)

--- a/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnUndockingComplete_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/VehicleDockingBay_OnUndockingComplete_Patch.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxModel.Helper;
@@ -11,7 +11,11 @@ namespace NitroxPatcher.Patches.Dynamic
 
         public static void Prefix(VehicleDockingBay __instance, Player player)
         {
+#if SUBNAUTICA
             Vehicle vehicle = __instance.GetDockedVehicle();
+#elif BELOWZERO
+            Vehicle vehicle = __instance.GetDockedObject().vehicle;
+#endif
             Resolve<Vehicles>().BroadcastVehicleUndocking(__instance, vehicle, false);
         }
 

--- a/NitroxPatcher/Patches/Dynamic/uGUI_PDA_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_PDA_Initialize_Patch.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/NitroxPatcher/Patches/Dynamic/uGUI_PDA_SetTabs_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/uGUI_PDA_SetTabs_Patch.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NitroxClient.GameLogic.HUD;
 using NitroxModel.Helper;
+using UnityEngine;
 
 namespace NitroxPatcher.Patches.Dynamic;
 
@@ -36,7 +37,7 @@ public class uGUI_PDA_SetTabs_Patch : NitroxPatch, IDynamicPatch
         }
     }
 
-    public static void SetupNitroxIcons(uGUI_PDA __instance, Atlas.Sprite[] array)
+    public static void SetupNitroxIcons(uGUI_PDA __instance, Sprite[] array)
     {
         // In the case SetTabs is used with a null value (from TimeCapsule for example)
         if (array.Length == 0)
@@ -53,7 +54,7 @@ public class uGUI_PDA_SetTabs_Patch : NitroxPatch, IDynamicPatch
             int tabIndex = customTabs.Count - i - 1;
 
             string tabIconAssetName = customTabs[tabIndex].TabIconAssetName;
-            if (!nitroxTabManager.TryGetTabSprite(tabIconAssetName, out Atlas.Sprite sprite))
+            if (!nitroxTabManager.TryGetTabSprite(tabIconAssetName, out Sprite sprite))
             {
                 nitroxTabManager.SetSpriteLoadedCallback(tabIconAssetName, callbackSprite => AssignSprite(__instance.toolbar, arrayIndex, callbackSprite));
                 // Take the fallback icon from another tab
@@ -63,7 +64,7 @@ public class uGUI_PDA_SetTabs_Patch : NitroxPatch, IDynamicPatch
         }
     }
 
-    private static void AssignSprite(uGUI_Toolbar toolbar, int index, Atlas.Sprite sprite)
+    private static void AssignSprite(uGUI_Toolbar toolbar, int index, Sprite sprite)
     {
         if (index < toolbar.icons.Count)
         {

--- a/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/EscapePodFirstUseCinematicsController_Initialize_Patch.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+#if SUBNAUTICA
+using System.Reflection;
 using HarmonyLib;
 using NitroxClient.MonoBehaviours;
 using NitroxModel.Helper;
@@ -26,3 +27,4 @@ namespace NitroxPatcher.Patches.Persistent
         }
     }
 }
+#endif

--- a/NitroxPatcher/Patches/Persistent/MainGameController_ShouldPlayIntro_Patch.cs
+++ b/NitroxPatcher/Patches/Persistent/MainGameController_ShouldPlayIntro_Patch.cs
@@ -6,7 +6,11 @@ namespace NitroxPatcher.Patches.Persistent;
 
 public class MainGameController_ShouldPlayIntro_Patch : NitroxPatch, IPersistentPatch
 {
+#if SUBNAUTICA
     private static readonly MethodInfo TARGET_METHOD = Reflect.Method(() => MainGameController.ShouldPlayIntro());
+#elif BELOWZERO
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((IntroVignette t) => t.ShouldPlayIntro());
+#endif
 
     public static void Postfix(ref bool __result)
     {

--- a/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
+++ b/NitroxServer-Subnautica/NitroxServer-Subnautica.csproj
@@ -6,6 +6,7 @@
         <RootNamespace>NitroxServer_Subnautica</RootNamespace>
         <Nullable>disable</Nullable>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,7 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AssetsTools.NET" Version="3.0.0-preview1" />
+        <PackageReference Include="AssetsTools.NET" Version="3.0.0-preview2" />
+        <PackageReference Include="AssetsTools.NET.Texture" Version="1.0.0-preview1" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -1,4 +1,4 @@
-﻿global using NitroxModel.Logger;
+global using NitroxModel.Logger;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -222,7 +222,11 @@ public class Program
         if (dllPath.IndexOf("Newtonsoft.Json.dll", StringComparison.OrdinalIgnoreCase) >= 0 || !File.Exists(dllPath))
         {
             // Try find game managed libraries
+#if SUBNAUTICA
             dllPath = Path.Combine(gameInstallDir.Value, "Subnautica_Data", "Managed", dllFileName);
+#elif BELOWZERO
+            dllPath = Path.Combine(gameInstallDir.Value, "SubnauticaZero_Data", "Managed", dllFileName);
+#endif
         }
 
         // Read assemblies as bytes as to not lock the file so that Nitrox can patch assemblies while server is running.

--- a/NitroxServer-Subnautica/Program.cs
+++ b/NitroxServer-Subnautica/Program.cs
@@ -63,11 +63,16 @@ public class Program
             Stopwatch watch = Stopwatch.StartNew();
 
             // Allow game path to be given as command argument
+#if SUBNAUTICA
             if (args.Length > 0 && Directory.Exists(args[0]) && File.Exists(Path.Combine(args[0], "Subnautica.exe")))
+#elif BELOWZERO
+            if (args.Length > 0 && Directory.Exists(args[0]) && File.Exists(Path.Combine(args[0], "SubnauticaZero.exe")))
+#endif
             {
                 string gameDir = Path.GetFullPath(args[0]);
                 Log.Info($"Using game files from: {gameDir}");
                 gameInstallDir = new Lazy<string>(() => gameDir);
+                NitroxUser.GamePath = gameDir;
             }
             else
             {

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/AddressablesBinaryParser.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/AddressablesBinaryParser.cs
@@ -1,0 +1,19 @@
+using System.IO;
+using AddressablesTools.Catalog;
+using AddressablesTools.Binary;
+
+namespace AddressablesTools
+{
+    public static class AddressablesBinaryParser
+    {
+        public static ContentCatalogData FromPath(string path)
+        {
+            using FileStream input = File.OpenRead(path);
+            using BinaryReader binaryReader = new(input);
+            ContentCatalogDataBinary ccdBinary = new ContentCatalogDataBinary();
+            ccdBinary.ReadBinary(binaryReader);
+
+            return ccdBinary;
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/AddressablesJsonParser.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/AddressablesJsonParser.cs
@@ -1,4 +1,4 @@
-﻿using AddressablesTools.Catalog;
+using AddressablesTools.Catalog;
 using AddressablesTools.JSON;
 using Newtonsoft.Json;
 
@@ -19,6 +19,16 @@ namespace AddressablesTools
             catalogData.Read(ccdJson);
 
             return catalogData;
+        }
+
+        public static string ToJson(ContentCatalogData ccd)
+        {
+            ContentCatalogDataJson ccdJson = new ContentCatalogDataJson();
+
+            ccd.Write(ccdJson);
+
+
+            return JsonConvert.SerializeObject(ccdJson);
         }
     }
 }

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/ContentCatalogDataBinary.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/ContentCatalogDataBinary.cs
@@ -1,0 +1,152 @@
+using AddressablesTools.JSON;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AddressablesTools.Catalog;
+
+namespace AddressablesTools.Binary
+{
+    public class ContentCatalogDataBinary : ContentCatalogData
+    {
+        private byte[] keyData;
+        private Bucket[] buckets;
+        private byte[] entryData;
+        private byte[] extraData;
+
+        public void ReadBinary(BinaryReader reader)
+        {
+            LocatorId = reader.ReadString();
+            InstanceProviderData = ObjectInitializationDataBinary.ReadBinary(reader);
+            SceneProviderData = ObjectInitializationDataBinary.ReadBinary(reader);
+
+            ResourceProviderData = ReadObjectArray<ObjectInitializationData>(reader, ObjectInitializationDataBinary.ReadBinary);
+
+            ProviderIds = ReadStringArray(reader);
+            InternalIds = ReadStringArray(reader);
+            keyData = ReadByteArray(reader);
+
+            buckets = ReadObjectArray(reader, Bucket.ReadBinary);
+
+            entryData = ReadByteArray(reader);
+            extraData = ReadByteArray(reader);
+
+            ResourceTypes = ReadObjectArray<SerializedType>(reader, SerializedTypeBinary.ReadBinary);
+
+            ReadResources();
+
+        }
+
+        private void ReadResources()
+        {
+
+            List<object> keys;
+
+            MemoryStream keyDataStream = new MemoryStream(keyData);
+            using (BinaryReader keyReader = new BinaryReader(keyDataStream))
+            {
+                int keyCount = keyReader.ReadInt32();
+                keys = new List<object>(keyCount);
+
+                for (int i = 0; i < keyCount; i++)
+                {
+                    keyDataStream.Position = buckets[i].offset;
+                    keys.Add(SerializedObjectDecoder.Decode(keyReader));
+                }
+            }
+
+            List<ResourceLocation> locations;
+
+            MemoryStream entryDataStream = new MemoryStream(entryData);
+            MemoryStream extraDataStream = new MemoryStream(extraData);
+            using (BinaryReader entryReader = new BinaryReader(entryDataStream))
+            using (BinaryReader extraReader = new BinaryReader(extraDataStream))
+            {
+                int entryCount = entryReader.ReadInt32();
+                locations = new List<ResourceLocation>(entryCount);
+
+                for (int i = 0; i < entryCount; i++)
+                {
+                    int internalIdIndex = entryReader.ReadInt32();
+                    int providerIndex = entryReader.ReadInt32();
+                    int dependencyKeyIndex = entryReader.ReadInt32();
+                    int depHash = entryReader.ReadInt32();
+                    int dataIndex = entryReader.ReadInt32();
+                    int primaryKeyIndex = entryReader.ReadInt32();
+                    int resourceTypeIndex = entryReader.ReadInt32();
+
+                    string internalId = InternalIds[internalIdIndex];
+
+                    string providerId = ProviderIds[providerIndex];
+
+                    object dependencyKey = null;
+                    if (dependencyKeyIndex >= 0)
+                    {
+                        dependencyKey = keys[dependencyKeyIndex];
+                    }
+
+                    object objData = null;
+                    if (dataIndex >= 0)
+                    {
+                        extraDataStream.Position = dataIndex;
+                        objData = SerializedObjectDecoder.Decode(extraReader);
+                    }
+
+                    object primaryKey = keys[primaryKeyIndex];
+                    SerializedType resourceType = ResourceTypes[resourceTypeIndex];
+
+                    var loc = new ResourceLocation();
+                    loc.ReadCompact(internalId, providerId, dependencyKey, objData, depHash, primaryKey, resourceType);
+                    locations.Add(loc);
+                }
+            }
+
+            Resources = new Dictionary<object, List<ResourceLocation>>(buckets.Length);
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                int[] bucketEntries = buckets[i].entries;
+                List<ResourceLocation> locs = new List<ResourceLocation>(bucketEntries.Length);
+                for (int j = 0; j < bucketEntries.Length; j++)
+                {
+                    locs.Add(locations[bucketEntries[j]]);
+                }
+                Resources[keys[i]] = locs;
+            }
+        }
+
+        private static T[] ReadObjectArray<T>(BinaryReader reader, Func<BinaryReader, T> deserializer)
+        {
+            int length = reader.ReadInt32();
+            T[] arr = new T[length];
+            for (int i = 0; i < length; i++)
+            {
+                arr[i] = deserializer(reader);
+            }
+
+            return arr;
+        }
+
+        private static string[] ReadStringArray(BinaryReader reader)
+        {
+            int length = reader.ReadInt32();
+            string[] arr = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                arr[i] = reader.ReadString();
+            }
+
+            return arr;
+        }
+
+        private static byte[] ReadByteArray(BinaryReader reader)
+        {
+            int length = reader.ReadInt32();
+            byte[] arr = new byte[length];
+            for (int i = 0; i < length; i++)
+            {
+                arr[i] = reader.ReadByte();
+            }
+
+            return arr;
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/ObjectInitializationDataBinary.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/ObjectInitializationDataBinary.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using AddressablesTools.Catalog;
+
+namespace AddressablesTools.Binary
+{
+    internal class ObjectInitializationDataBinary : ObjectInitializationData
+    {
+        public static ObjectInitializationDataBinary ReadBinary(BinaryReader reader)
+        {
+            return new ObjectInitializationDataBinary
+            {
+                Id = reader.ReadString(),
+                ObjectType = SerializedTypeBinary.ReadBinary(reader),
+                Data = reader.ReadString()
+            };
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/SerializedTypeBinary.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Binary/SerializedTypeBinary.cs
@@ -1,0 +1,17 @@
+using System.IO;
+using AddressablesTools.Catalog;
+
+namespace AddressablesTools.Binary
+{
+    internal class SerializedTypeBinary : SerializedType
+    {
+        public static SerializedTypeBinary ReadBinary(BinaryReader reader)
+        {
+            return new SerializedTypeBinary
+            {
+                AssemblyName = reader.ReadString(),
+                ClassName = reader.ReadString()
+            };
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ClassJsonObject.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ClassJsonObject.cs
@@ -1,10 +1,10 @@
-﻿namespace AddressablesTools.Catalog
+namespace AddressablesTools.Catalog
 {
-    internal class ClassJsonObject
+    public class ClassJsonObject
     {
-        public string AssemblyName { get; }
-        public string ClassName { get; }
-        public string JsonText { get; }
+        public string AssemblyName { get; set; }
+        public string ClassName { get; set; }
+        public string JsonText { get; set; }
 
         public ClassJsonObject(string assemblyName, string className, string jsonText)
         {

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ContentCatalogData.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ContentCatalogData.cs
@@ -1,20 +1,24 @@
-﻿using AddressablesTools.JSON;
+using AddressablesTools.JSON;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace AddressablesTools.Catalog
 {
+    [Newtonsoft.Json.JsonObject(MemberSerialization.Fields)]
     public class ContentCatalogData
     {
         public string LocatorId { get; set; }
         public ObjectInitializationData InstanceProviderData { get; set; }
         public ObjectInitializationData SceneProviderData { get; set; }
         public ObjectInitializationData[] ResourceProviderData { get; set; }
-        public string[] ProviderIds { get; set; }
-        public string[] InternalIds { get; set; }
-        public SerializedType[] ResourceTypes { get; set; }
-        public string[] InternalIdPrefixes { get; set; }
+        // used for resources, shouldn't be edited directly
+        protected string[] ProviderIds { get; set; }
+        protected string[] InternalIds { get; set; }
+        protected SerializedType[] ResourceTypes { get; set; }
+        private string[] InternalIdPrefixes { get; set; } // todo
 
         public Dictionary<object, List<ResourceLocation>> Resources { get; set; }
 
@@ -162,7 +166,169 @@ namespace AddressablesTools.Catalog
             }
         }
 
-        private struct Bucket
+        internal void Write(ContentCatalogDataJson data)
+        {
+            data.m_LocatorId = LocatorId;
+
+            data.m_InstanceProviderData = new ObjectInitializationDataJson();
+            InstanceProviderData.Write(data.m_InstanceProviderData);
+
+            data.m_SceneProviderData = new ObjectInitializationDataJson();
+            SceneProviderData.Write(data.m_SceneProviderData);
+
+            data.m_ResourceProviderData = new ObjectInitializationDataJson[ResourceProviderData.Length];
+            for (int i = 0; i < data.m_ResourceProviderData.Length; i++)
+            {
+                data.m_ResourceProviderData[i] = new ObjectInitializationDataJson();
+                ResourceProviderData[i].Write(data.m_ResourceProviderData[i]);
+            }
+
+            WriteResources(data);
+
+            data.m_ProviderIds = new string[ProviderIds.Length];
+            for (int i = 0; i < data.m_ProviderIds.Length; i++)
+            {
+                data.m_ProviderIds[i] = ProviderIds[i];
+            }
+
+            data.m_InternalIds = new string[InternalIds.Length];
+            for (int i = 0; i < data.m_InternalIds.Length; i++)
+            {
+                data.m_InternalIds[i] = InternalIds[i];
+            }
+
+            data.m_resourceTypes = new SerializedTypeJson[ResourceTypes.Length];
+            for (int i = 0; i < data.m_resourceTypes.Length; i++)
+            {
+                data.m_resourceTypes[i] = new SerializedTypeJson();
+                ResourceTypes[i].Write(data.m_resourceTypes[i]);
+            }
+
+            data.m_InternalIdPrefixes = new string[InternalIdPrefixes.Length];
+            for (int i = 0; i < data.m_InternalIdPrefixes.Length; i++)
+            {
+                data.m_InternalIdPrefixes[i] = InternalIdPrefixes[i];
+            }
+        }
+
+        private void WriteResources(ContentCatalogDataJson data)
+        {
+            HashSet<string> newInternalIdHs = new HashSet<string>();
+            HashSet<string> newProviderIdHs = new HashSet<string>();
+            HashSet<SerializedType> newResourceTypeHs = new HashSet<SerializedType>();
+            //HashSet<string> newInternalIdPrefixes = new HashSet<string>(); // todo
+
+            HashSet<ResourceLocation> newLocationHs = new HashSet<ResourceLocation>();
+
+            List<object> newKeys = Resources.Keys.ToList();
+
+            foreach (var value in Resources.Values)
+            {
+                foreach (var location in value)
+                {
+                    newLocationHs.Add(location);
+
+                    if (location.InternalId == null)
+                        throw new Exception("Location's internal ID cannot be null!");
+
+                    if (location.ProviderId == null)
+                        throw new Exception("Location's provider ID cannot be null!");
+
+                    newInternalIdHs.Add(location.InternalId);
+                    newProviderIdHs.Add(location.ProviderId);
+
+                    if (location.Type != null)
+                    {
+                        newResourceTypeHs.Add(location.Type);
+                    }
+                }
+            }
+
+            List<string> newInternalIds = newInternalIdHs.ToList();
+            List<string> newProviderIds = newProviderIdHs.ToList();
+            List<SerializedType> newResourceTypes = newResourceTypeHs.ToList();
+            List<ResourceLocation> newLocations = newLocationHs.ToList();
+
+            MemoryStream entryDataStream = new MemoryStream();
+            MemoryStream extraDataStream = new MemoryStream();
+            using (BinaryWriter entryWriter = new BinaryWriter(entryDataStream))
+            using (BinaryWriter extraWriter = new BinaryWriter(extraDataStream))
+            {
+                entryWriter.Write(newLocationHs.Count);
+
+                foreach (var location in newLocationHs)
+                {
+                    int internalIdIndex = newInternalIds.IndexOf(location.InternalId);
+                    int providerIndex = newProviderIds.IndexOf(location.ProviderId);
+                    int dependencyKeyIndex = (location.Dependency == null) ? -1 : newKeys.IndexOf(location.Dependency);
+                    int depHash = location.DependencyHashCode; // todo calculate this
+                    int dataIndex = -1;
+                    if (location.Data != null)
+                    {
+                        dataIndex = (int)extraDataStream.Position;
+                        SerializedObjectDecoder.Encode(extraWriter, location.Data);
+                    }
+                    int primaryKeyIndex = newKeys.IndexOf(location.PrimaryKey);
+                    int resourceTypeIndex = newResourceTypes.IndexOf(location.Type);
+
+                    entryWriter.Write(internalIdIndex);
+                    entryWriter.Write(providerIndex);
+                    entryWriter.Write(dependencyKeyIndex);
+                    entryWriter.Write(depHash);
+                    entryWriter.Write(dataIndex);
+                    entryWriter.Write(primaryKeyIndex);
+                    entryWriter.Write(resourceTypeIndex);
+                }
+            }
+
+            MemoryStream keyDataStream = new MemoryStream();
+            MemoryStream bucketStream = new MemoryStream();
+            using (BinaryWriter keyWriter = new BinaryWriter(keyDataStream))
+            using (BinaryWriter bucketWriter = new BinaryWriter(bucketStream))
+            {
+                keyWriter.Write(newKeys.Count); // same as Resources.Count
+                bucketWriter.Write(newKeys.Count);
+
+                foreach (var resourceKvp in Resources)
+                {
+                    object resourceKey = resourceKvp.Key;
+                    List<ResourceLocation> resourceValue = resourceKvp.Value;
+
+                    Bucket bucket = new Bucket
+                    {
+                        offset = (int)keyDataStream.Position,
+                        entries = new int[resourceValue.Count]
+                    };
+
+                    // write key
+                    SerializedObjectDecoder.Encode(keyWriter, resourceKey);
+
+                    for (int i = 0; i < resourceValue.Count; i++)
+                    {
+                        bucket.entries[i] = newLocations.IndexOf(resourceValue[i]);
+                    }
+
+                    // write bucket
+                    bucketWriter.Write(bucket.offset);
+                    bucketWriter.Write(bucket.entries.Length);
+                    for (int i = 0; i < bucket.entries.Length; i++)
+                    {
+                        bucketWriter.Write(bucket.entries[i]);
+                    }
+                }
+            }
+
+            ProviderIds = newProviderIds.ToArray();
+            InternalIds = newInternalIds.ToArray();
+            ResourceTypes = newResourceTypes.ToArray();
+
+            data.m_BucketDataString = Convert.ToBase64String(bucketStream.ToArray());
+            data.m_KeyDataString = Convert.ToBase64String(keyDataStream.ToArray());
+            data.m_EntryDataString = Convert.ToBase64String(entryDataStream.ToArray());
+            data.m_ExtraDataString = Convert.ToBase64String(extraDataStream.ToArray());
+        }
+
+        protected struct Bucket
         {
             public int offset;
             public int[] entries;
@@ -171,6 +337,19 @@ namespace AddressablesTools.Catalog
             {
                 this.offset = offset;
                 this.entries = entries;
+            }
+            public static Bucket ReadBinary(BinaryReader reader)
+            {
+                int offset = reader.ReadInt32();
+
+                int arrayLength = reader.ReadInt32();
+                int[] entries = new int[arrayLength];
+                for (int i = 0; i < arrayLength; i++)
+                {
+                    entries[i] = reader.ReadInt32();
+                }
+
+                return new Bucket(offset, entries);
             }
         }
     }

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ObjectInitializationData.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/ObjectInitializationData.cs
@@ -1,4 +1,4 @@
-﻿using AddressablesTools.JSON;
+using AddressablesTools.JSON;
 
 namespace AddressablesTools.Catalog
 {
@@ -14,6 +14,14 @@ namespace AddressablesTools.Catalog
             ObjectType = new SerializedType();
             ObjectType.Read(obj.m_ObjectType);
             Data = obj.m_Data;
+        }
+
+        internal void Write(ObjectInitializationDataJson obj)
+        {
+            obj.m_Id = Id;
+            obj.m_ObjectType = new SerializedTypeJson();
+            ObjectType.Write(obj.m_ObjectType);
+            obj.m_Data = Data;
         }
     }
 }

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/SerializedObjectDecoder.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/SerializedObjectDecoder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using AddressablesTools.Classes;
+using System;
 using System.IO;
 using System.Text;
 
@@ -21,62 +22,136 @@ namespace AddressablesTools.Catalog
         internal static object Decode(BinaryReader br)
         {
             ObjectType type = (ObjectType)br.ReadByte();
-            
+
             switch (type)
             {
                 case ObjectType.AsciiString:
-                {
-                    string str = ReadString4(br);
-                    return str;
-                }
+                    {
+                        string str = ReadString4(br);
+                        return str;
+                    }
 
                 case ObjectType.UnicodeString:
-                {
-                    string str = ReadString4Unicode(br);
-                    return str;
-                }
+                    {
+                        string str = ReadString4Unicode(br);
+                        return str;
+                    }
 
                 case ObjectType.UInt16:
-                {
-                    return br.ReadUInt16();
-                }
+                    {
+                        return br.ReadUInt16();
+                    }
 
                 case ObjectType.UInt32:
-                {
-                    return br.ReadUInt32();
-                }
+                    {
+                        return br.ReadUInt32();
+                    }
 
                 case ObjectType.Int32:
-                {
-                    return br.ReadInt32();
-                }
+                    {
+                        return br.ReadInt32();
+                    }
 
                 case ObjectType.Hash128:
-                {
-                    // read as string for now
-                    string str = ReadString1(br);
-                    return str;
-                }
+                    {
+                        // read as string for now
+                        string str = ReadString1(br);
+                        Hash128 hash = new Hash128(str);
+                        return hash;
+                    }
 
                 case ObjectType.Type:
-                {
-                    string str = ReadString1(br);
-                    return Type.GetTypeFromCLSID(new Guid(str));
-                }
+                    {
+                        string str = ReadString1(br);
+                        TypeReference typeReference = new TypeReference(str);
+                        return typeReference;
+                    }
 
                 case ObjectType.JsonObject:
-                {
-                    string assemblyName = ReadString1(br);
-                    string className = ReadString1(br);
-                    string jsonText = ReadString4Unicode(br);
-                    ClassJsonObject jsonObj = new ClassJsonObject(assemblyName, className, jsonText);
-                    return jsonObj;
-                }
+                    {
+                        string assemblyName = ReadString1(br);
+                        string className = ReadString1(br);
+                        string jsonText = ReadString4Unicode(br);
+                        ClassJsonObject jsonObj = new ClassJsonObject(assemblyName, className, jsonText);
+                        return jsonObj;
+                    }
 
                 default:
-                {
-                    return null;
-                }
+                    {
+                        return null;
+                    }
+            }
+        }
+
+        internal static void Encode(BinaryWriter bw, object ob)
+        {
+            switch (ob)
+            {
+                case string str:
+                    {
+                        byte[] asciiEncoding = Encoding.ASCII.GetBytes(str);
+                        string asciiText = Encoding.ASCII.GetString(asciiEncoding);
+                        if (str != asciiText)
+                        {
+                            bw.Write((byte)ObjectType.UnicodeString);
+                            WriteString4Unicode(bw, str);
+                        }
+                        else
+                        {
+                            bw.Write((byte)ObjectType.AsciiString);
+                            WriteString4(bw, str);
+                        }
+                        break;
+                    }
+
+                case ushort ush:
+                    {
+                        bw.Write((byte)ObjectType.UInt16);
+                        bw.Write(ush);
+                        break;
+                    }
+
+                case uint uin:
+                    {
+                        bw.Write((byte)ObjectType.UInt32);
+                        bw.Write(uin);
+                        break;
+                    }
+
+                case int i:
+                    {
+                        bw.Write((byte)ObjectType.Int32);
+                        bw.Write(i);
+                        break;
+                    }
+
+                case Hash128 hash:
+                    {
+                        bw.Write((byte)ObjectType.Hash128);
+                        bw.Write(hash.Value);
+                        break;
+                    }
+
+                case TypeReference type:
+                    {
+                        bw.Write((byte)ObjectType.Type);
+                        WriteString1(bw, type.Clsid);
+                        break;
+                    }
+
+                case ClassJsonObject jsonObject:
+                    {
+                        bw.Write((byte)ObjectType.JsonObject);
+                        WriteString1(bw, jsonObject.AssemblyName);
+                        WriteString1(bw, jsonObject.ClassName);
+                        WriteString4Unicode(bw, jsonObject.JsonText);
+                        break;
+                    }
+
+                default:
+                    {
+                        throw new Exception($"Type {ob.GetType().FullName} not supported!");
+                    }
             }
         }
 
@@ -99,6 +174,30 @@ namespace AddressablesTools.Catalog
             int length = br.ReadInt32();
             string str = Encoding.Unicode.GetString(br.ReadBytes(length));
             return str;
+        }
+
+        private static void WriteString1(BinaryWriter bw, string str)
+        {
+            if (str.Length > 255)
+                throw new ArgumentException("String length cannot be greater than 255.");
+
+            byte[] bytes = Encoding.ASCII.GetBytes(str);
+            bw.Write((byte)bytes.Length);
+            bw.Write(bytes);
+        }
+
+        private static void WriteString4(BinaryWriter bw, string str)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes(str);
+            bw.Write(bytes.Length);
+            bw.Write(bytes);
+        }
+
+        private static void WriteString4Unicode(BinaryWriter bw, string str)
+        {
+            byte[] bytes = Encoding.Unicode.GetBytes(str);
+            bw.Write(bytes.Length);
+            bw.Write(bytes);
         }
     }
 }

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/SerializedType.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Catalog/SerializedType.cs
@@ -1,4 +1,4 @@
-﻿using AddressablesTools.JSON;
+using AddressablesTools.JSON;
 
 namespace AddressablesTools.Catalog
 {
@@ -7,10 +7,32 @@ namespace AddressablesTools.Catalog
         public string AssemblyName { get; set; }
         public string ClassName { get; set; }
 
+        public override bool Equals(object obj)
+        {
+            return obj is SerializedType type &&
+                                       AssemblyName == type.AssemblyName &&
+                                       ClassName == type.ClassName;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((AssemblyName != null ? AssemblyName.GetHashCode() : 0) * 397) ^
+                                               (ClassName != null ? ClassName.GetHashCode() : 0);
+            }
+        }
+
         internal void Read(SerializedTypeJson type)
         {
             AssemblyName = type.m_AssemblyName;
             ClassName = type.m_ClassName;
+        }
+
+        internal void Write(SerializedTypeJson type)
+        {
+            type.m_AssemblyName = AssemblyName;
+            type.m_ClassName = ClassName;
         }
     }
 }

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Classes/Hash128.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Classes/Hash128.cs
@@ -1,0 +1,12 @@
+namespace AddressablesTools.Classes
+{
+    public class Hash128
+    {
+        public string Value { get; set; }
+
+        public Hash128(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/AddressablesTools/Classes/TypeReference.cs
+++ b/NitroxServer-Subnautica/Resources/AddressablesTools/Classes/TypeReference.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace AddressablesTools.Classes
+{
+    public class TypeReference
+    {
+        public string Clsid { get; set; }
+
+        public TypeReference(string clsid)
+        {
+            Clsid = clsid;
+        }
+    }
+}

--- a/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Abstract/AssetParser.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AssetsTools.NET.Extra;
 using NitroxServer_Subnautica.Resources.Parsers.Helper;
 

--- a/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsBundleManager.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/Helper/AssetsBundleManager.cs
@@ -117,11 +117,17 @@ public class AssetsBundleManager : AssetsManager
     /// </summary>
     public AssetsBundleManager Clone()
     {
+#if SUBNAUTICA
         AssetsBundleManager bundleManagerInst = new(aaRootPath)
         {
             classDatabase = classDatabase, 
             classPackage = classPackage
         };
+#elif BELOWZERO
+        AssetsBundleManager bundleManagerInst = new(aaRootPath);
+        bundleManagerInst.LoadClassPackage("classdata.tpk");
+        bundleManagerInst.LoadClassDatabaseFromPackage("2019.4.36f1");
+#endif
         bundleManagerInst.SetMonoTempGenerator(monoTempGenerator);
         return bundleManagerInst;
     }

--- a/NitroxServer-Subnautica/Resources/Parsers/RandomStartParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/RandomStartParser.cs
@@ -1,8 +1,9 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
+using AssetsTools.NET.Texture;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer_Subnautica.Resources.Parsers.Abstract;
 using NitroxServer_Subnautica.Resources.Parsers.Helper;

--- a/NitroxServer-Subnautica/Resources/Parsers/WorldEntityInfoParser.cs
+++ b/NitroxServer-Subnautica/Resources/Parsers/WorldEntityInfoParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using NitroxServer_Subnautica.Resources.Parsers.Abstract;
@@ -18,6 +18,16 @@ public class WorldEntityInfoParser : ResourceFileParser<Dictionary<string, World
 
         foreach (AssetTypeValueField info in assetValue["infos"])
         {
+            var a = info["classId"];
+            var aa = info["classId"].AsString;
+            var b = info["techType"];
+            var bb = info["techType"].AsInt;
+            var c = info["slotType"];
+            var cc = info["slotType"].AsInt;
+            var d = info["prefabZUp"];
+            var dd = info["prefabZUp"].AsBool;
+            var e = info["localScale"];
+            var ee = info["localScale"].AsVector3();
             WorldEntityInfo entityData = new()
             {
                 classId = info["classId"].AsString,

--- a/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
+++ b/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
@@ -27,7 +27,7 @@ public static class ResourceAssetsParser
         }
         AssetParser.Dispose();
         
-        ResourceAssets.ValidateMembers(resourceAssets);
+        //ResourceAssets.ValidateMembers(resourceAssets);
         return resourceAssets;
     }
 

--- a/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
+++ b/NitroxServer-Subnautica/Resources/ResourceAssetsParser.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using NitroxModel.Helper;
 using NitroxServer_Subnautica.Resources.Parsers;
 
@@ -34,6 +34,8 @@ public static class ResourceAssetsParser
     public static string FindDirectoryContainingResourceAssets()
     {
         string subnauticaPath = NitroxUser.GamePath;
+        //subnauticaPath = "E:\\Program Files\\Steam\\steamapps\\common\\Subnautica";
+#if SUBNAUTICA
         if (string.IsNullOrEmpty(subnauticaPath))
         {
             throw new DirectoryNotFoundException("Could not locate Subnautica installation directory for resource parsing.");
@@ -56,5 +58,29 @@ public static class ResourceAssetsParser
             return Directory.GetCurrentDirectory();
         }
         throw new FileNotFoundException("Make sure resources.assets is in current or parent directory and readable.");
+#elif BELOWZERO
+        if (string.IsNullOrEmpty(subnauticaPath))
+        {
+            throw new DirectoryNotFoundException("Could not locate Subnautica Below Zero installation directory for resource parsing.");
+        }
+
+        if (File.Exists(Path.Combine(subnauticaPath, "SubnauticaZero_Data", "resources.assets")))
+        {
+            return Path.Combine(subnauticaPath, "SubnauticaZero_Data");
+        }
+        if (File.Exists(Path.Combine("..", "resources.assets"))) //  SubServer => SubnauticaZero/SubnauticaZero_Data/SubServer
+        {
+            return Path.GetFullPath(Path.Combine(".."));
+        }
+        if (File.Exists(Path.Combine("..", "SubnauticaZero_Data", "resources.assets"))) //  SubServer => SubnauticaZero/SubServer
+        {
+            return Path.GetFullPath(Path.Combine("..", "SubnauticaZero_Data"));
+        }
+        if (File.Exists("resources.assets")) //  SubServer/* => SubnauticaZero/SubnauticaZero_Data/
+        {
+            return Directory.GetCurrentDirectory();
+        }
+        throw new FileNotFoundException("Make sure resources.assets is in current or parent directory and readable.");
+#endif
     }
 }

--- a/NitroxServer/Communication/Packets/Processors/PlayerStatsProcessor.cs
+++ b/NitroxServer/Communication/Packets/Processors/PlayerStatsProcessor.cs
@@ -1,4 +1,4 @@
-﻿using NitroxModel.Packets;
+using NitroxModel.Packets;
 using NitroxServer.Communication.Packets.Processors.Abstract;
 using NitroxServer.GameLogic;
 
@@ -15,7 +15,11 @@ namespace NitroxServer.Communication.Packets.Processors
 
         public override void Process(PlayerStats packet, Player player)
         {
+#if SUBNAUTICA
             player.Stats = new NitroxModel.DataStructures.GameLogic.PlayerStatsData(packet.Oxygen, packet.MaxOxygen, packet.Health, packet.Food, packet.Water, packet.InfectionAmount);
+#elif BELOWZERO
+            player.Stats = new NitroxModel.DataStructures.GameLogic.PlayerStatsData(packet.Oxygen, packet.MaxOxygen, packet.Health, packet.Food, packet.Water);
+#endif
             playerManager.SendPacketToOtherPlayers(packet, player);
         }
     }

--- a/NitroxServer/ConsoleCommands/AuroraCommand.cs
+++ b/NitroxServer/ConsoleCommands/AuroraCommand.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.ConsoleCommands.Abstract.Type;
@@ -40,3 +41,4 @@ public class AuroraCommand : Command
         }
     }
 }
+#endif

--- a/NitroxServer/ConsoleCommands/SunbeamCommand.cs
+++ b/NitroxServer/ConsoleCommands/SunbeamCommand.cs
@@ -1,3 +1,4 @@
+#if SUBNAUTICA
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Packets;
 using NitroxServer.ConsoleCommands.Abstract;
@@ -46,3 +47,4 @@ public class SunbeamCommand : Command
         }
     }
 }
+#endif

--- a/NitroxServer/ConsoleCommands/WhoisCommand.cs
+++ b/NitroxServer/ConsoleCommands/WhoisCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxServer.ConsoleCommands.Abstract;
 using NitroxServer.ConsoleCommands.Abstract.Type;
@@ -23,7 +23,9 @@ namespace NitroxServer.ConsoleCommands
             builder.AppendLine($"Oxygen: {player.Stats.Oxygen}/{player.Stats.MaxOxygen}");
             builder.AppendLine($"Food: {player.Stats.Food}");
             builder.AppendLine($"Water: {player.Stats.Water}");
+#if SUBNAUTICA
             builder.AppendLine($"Infection: {player.Stats.InfectionAmount}");
+#endif
 
             SendMessage(args.Sender, builder.ToString());
         }

--- a/NitroxServer/GameLogic/StoryManager.cs
+++ b/NitroxServer/GameLogic/StoryManager.cs
@@ -33,19 +33,23 @@ public class StoryManager
 
     private double ElapsedMilliseconds => timeKeeper.ElapsedMilliseconds;
     private double ElapsedSeconds => timeKeeper.ElapsedSeconds;
-
+#if SUBNAUTICA
     public StoryManager(PlayerManager playerManager, PDAStateData pdaStateData, StoryGoalData storyGoalData, TimeKeeper timeKeeper, string seed, double? auroraExplosionTime, double? auroraWarningTime)
+#elif BELOWZERO
+    public StoryManager(PlayerManager playerManager, PDAStateData pdaStateData, StoryGoalData storyGoalData, TimeKeeper timeKeeper, string seed)
+#endif
     {
         this.playerManager = playerManager;
         this.pdaStateData = pdaStateData;
         this.storyGoalData = storyGoalData;
         this.timeKeeper = timeKeeper;
         this.seed = seed;
-        
+#if SUBNAUTICA
         AuroraCountdownTimeMs = auroraExplosionTime ?? GenerateDeterministicAuroraTime(seed);
         AuroraWarningTimeMs = auroraWarningTime ?? ElapsedMilliseconds;
+#endif
     }
-
+#if SUBNAUTICA
     /// <param name="instantaneous">Whether we should make Aurora explode instantly or after a short countdown</param>
     public void BroadcastExplodeAurora(bool instantaneous)
     {
@@ -161,10 +165,14 @@ public class StoryManager
     {
         return new((float)AuroraCountdownTimeMs * 0.001f, (float)AuroraWarningTimeMs * 0.001f);
     }
-
+#endif
     public TimeData GetTimeData()
     {
+#if SUBNAUTICA
         return new(timeKeeper.MakeTimePacket(), MakeAuroraData());
+#elif BELOWZERO
+        return new(timeKeeper.MakeTimePacket());
+#endif
     }
 
     public enum TimeModification

--- a/NitroxServer/GameLogic/StoryTimingData.cs
+++ b/NitroxServer/GameLogic/StoryTimingData.cs
@@ -9,20 +9,23 @@ namespace NitroxServer.GameLogic
     {
         [DataMember(Order = 1)]
         public double ElapsedSeconds { get; set; }
-
+#if SUBNAUTICA
         [DataMember(Order = 2)]
         public double? AuroraCountdownTime { get; set; }
 
         [DataMember(Order = 3)]
         public double? AuroraWarningTime { get; set; }
+#endif
 
         public static StoryTimingData From(StoryManager storyManager, TimeKeeper timeKeeper)
         {
             return new StoryTimingData
             {
                 ElapsedSeconds = timeKeeper.ElapsedSeconds,
+#if SUBNAUTICA
                 AuroraCountdownTime = storyManager.AuroraCountdownTimeMs,
                 AuroraWarningTime = storyManager.AuroraWarningTimeMs
+#endif
             };
         }
     }

--- a/NitroxServer/NitroxServer.csproj
+++ b/NitroxServer/NitroxServer.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
+        <Configurations>Debug;Release;BelowZero;Subnautica</Configurations>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -57,7 +57,11 @@ namespace NitroxServer.Serialization
                 return;
             }
 
+#if SUBNAUTICA
             string path = Path.Combine(subnauticaPath, "Subnautica_Data", "StreamingAssets", "SNUnmanagedData", "Build18");
+#elif BELOWZERO
+            string path = Path.Combine(subnauticaPath, "SubnauticaZero_Data", "StreamingAssets", "SNUnmanagedData", "Expansion");
+#endif
             string fileName = Path.Combine(path, pathPrefix, $"{prefix}batch-cells-{batchId.X}-{batchId.Y}-{batchId.Z}{suffix}.bin");
 
             if (!File.Exists(fileName))

--- a/NitroxServer/Serialization/ServerConfig.cs
+++ b/NitroxServer/Serialization/ServerConfig.cs
@@ -1,4 +1,4 @@
-﻿using NitroxModel.DataStructures.GameLogic;
+using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.Helper;
 using NitroxModel.Serialization;
 using NitroxModel.Server;
@@ -103,13 +103,18 @@ namespace NitroxServer.Serialization
         public float DefaultHealthValue { get; set; } = 80;
         public float DefaultHungerValue { get; set; } = 50.5f;
         public float DefaultThirstValue { get; set; } = 90.5f;
-
+#if SUBNAUTICA
         [PropertyDescription("Recommended to keep at 0.1f which is the default starting value. If set to 0 then new players are cured by default.")]
         public float DefaultInfectionValue { get; set; } = 0.1f;
+#endif
 
         public bool IsHardcore => GameMode == ServerGameMode.HARDCORE;
         public bool IsPasswordRequired => ServerPassword != string.Empty;
+#if SUBNAUTICA
         public PlayerStatsData DefaultPlayerStats => new(DefaultOxygenValue, DefaultMaxOxygenValue, DefaultHealthValue, DefaultHungerValue, DefaultThirstValue, DefaultInfectionValue);
+#elif BELOWZERO
+        public PlayerStatsData DefaultPlayerStats => new(DefaultOxygenValue, DefaultMaxOxygenValue, DefaultHealthValue, DefaultHungerValue, DefaultThirstValue);
+#endif
         [PropertyDescription("If set to true, the server will try to open port on your router via UPnP")]
         public bool AutoPortForward { get; set; } = true;
         [PropertyDescription("Determines whether the server will listen for and reply to LAN discovery requests.")]

--- a/NitroxServer/Serialization/World/WorldPersistence.cs
+++ b/NitroxServer/Serialization/World/WorldPersistence.cs
@@ -211,7 +211,11 @@ namespace NitroxServer.Serialization.World
             };
 
             world.TimeKeeper = new(world.PlayerManager, pWorldData.WorldData.GameData.StoryTiming.ElapsedSeconds);
+#if SUBNAUTICA
             world.StoryManager = new(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, seed, pWorldData.WorldData.GameData.StoryTiming.AuroraCountdownTime, pWorldData.WorldData.GameData.StoryTiming.AuroraWarningTime);
+#elif BELOWZERO
+            world.StoryManager = new(world.PlayerManager, pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, seed);
+#endif
             world.ScheduleKeeper = new ScheduleKeeper(pWorldData.WorldData.GameData.PDAState, pWorldData.WorldData.GameData.StoryGoals, world.TimeKeeper, world.PlayerManager);
 
             world.BatchEntitySpawner = new BatchEntitySpawner(

--- a/NitroxServer/Server.cs
+++ b/NitroxServer/Server.cs
@@ -64,6 +64,7 @@ namespace NitroxServer
             {
                 builder.AppendLine($" - Save location: {Path.Combine(WorldManager.SavesFolderDir, serverConfig.SaveName)}");
             }
+#if SUBNAUTICA
             builder.AppendLine($"""
              - Aurora's state: {world.StoryManager.GetAuroraStateSummary()}
              - Current time: day {world.TimeKeeper.Day} ({Math.Floor(world.TimeKeeper.ElapsedSeconds)}s)
@@ -75,7 +76,18 @@ namespace NitroxServer
              - Encyclopedia entries: {world.GameData.PDAState.EncyclopediaEntries.Count}
              - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}
             """);
-                
+#elif BELOWZERO
+            builder.AppendLine($"""
+             - Current time: day {world.TimeKeeper.Day} ({Math.Floor(world.TimeKeeper.ElapsedSeconds)}s)
+             - Scheduled goals stored: {world.GameData.StoryGoals.ScheduledGoals.Count}
+             - Story goals completed: {world.GameData.StoryGoals.CompletedGoals.Count}
+             - Radio messages stored: {world.GameData.StoryGoals.RadioQueue.Count}
+             - World gamemode: {serverConfig.GameMode}
+             - Story goals unlocked: {world.GameData.StoryGoals.GoalUnlocks.Count}
+             - Encyclopedia entries: {world.GameData.PDAState.EncyclopediaEntries.Count}
+             - Known tech: {world.GameData.PDAState.KnownTechTypes.Count}
+            """);
+#endif
             return builder.ToString();
         }
 


### PR DESCRIPTION
It's all in the title.
I fixed the GameInstallationFinder so Below Zero is detectable when you're in configuration BelowZero if your game was downloaded from Steam.
I also fixed the SubnauticaData thingy, it was searching for Subnautica_Data inside game files without any variantion between games, which was not good for Below Zero, so I added an other #if statement to search for SubnauticaZero_Data when you're on the BelowZero configuration.